### PR TITLE
Add UNAPI RAM Helper compatible mapper support routines

### DIFF
--- a/source/kernel/bank1/dosinit.mac
+++ b/source/kernel/bank1/dosinit.mac
@@ -1544,17 +1544,143 @@ _all_fre_go:	push	de			;Must preserve everything
 		pop	hl
 		ret
 
-; Page 2 block memory allocation routines
+;
+;-----------------------------------------------------------------------------
+;
+; UNAPI RAM helper compatible routines
 
-_FR_BK:		ld	ix,FR_BK##
-		jr	_bk_go
-_ALL_BK:	ld	ix,ALL_BK##
+        ;--- Routine to call code in a RAM segment
+        ;    Input:
+        ;    IYh = Slot number
+        ;    IYl = Segment number
+        ;    IX = Target routine address (must be a page 1 address)
+        ;    AF, BC, DE, HL = Parameters for the target routine
+        ;Output:
+        ;    AF, BC, DE, HL, IX, IY = Parameters returned from the target
+        ;    routine
 
-_bk_go:		ld	(BK4_ADD##),ix
-		ld	iy,(MASTER_SLOT##-1)
-		ld	ix,?CALL4##
-		jp	CALSLT##
+_U_CALLRAM:
+        ex      af,af
+...	      < call	_GET_P1 >
+        push    af
+        ld_a_iyl
+...	      < call	_PUT_P1 >
+        ex      af,af
+        call    CALSLT##
+        ex      af,af
+        pop     af
+...	      < call	_PUT_P1 >
+        ex      af,af
+        ret
 
+
+        ;--- Routines to read or writea byte from a RAM segment
+        ;Input:
+        ;    A = Slot number
+        ;    B = Segment number
+        ;    E = Data to write (only WRITERAM)
+        ;    HL = Address to be read/written from
+        ;       (higher two bits will be ignored)
+        ;Output:
+        ;    A = Data read from the specified address (only READRAM)
+        ;    BC, DE, HL preserved
+
+_U_READRAM:
+        push ix
+        ld ix,RDSLT##
+        jr _U_RW
+
+_U_WRITERAM:
+        push ix
+        ld ix,WRSLT##
+
+_U_RW:
+        push bc
+        push de
+        push hl
+        ex      af,af
+...	      < call	_GET_P1 >
+        push    af
+        ld      a,b
+...	      < call	_PUT_P1 >
+        res     7,h
+        set     6,h
+        ex      af,af
+...	      < call	_U_JPIX >
+        ex      af,af
+        pop     af
+...	      < call	_PUT_P1 >
+        ex      af,af
+        pop hl
+        pop de
+        pop bc
+        pop ix
+        ret
+
+_U_JPIX:
+        jp (ix)        
+
+
+        ;--- Routine to call code in a RAM segment
+        ;    (code location specified in the stack)
+        ;Input:
+        ;    AF, BC, DE, HL = Parameters for the target routine
+        ;Output:
+        ;    AF, BC, DE, HL, IX, IY = Parameters returned from the target
+        ;    routine
+        ;Call as:
+        ;    CALL CALLRAM2
+        ;
+        ;CALLRAM2:
+        ;    CALL <routine address>
+        ;    DB bMMAAAAAA
+        ;    DB <segment number>
+        ;
+        ;    MM = Slot as the index of the entry in the mapper table.
+        ;    AAAAAA = Routine address index:
+        ;             0=4000h, 1=4003h, ..., 63=40BDh
+
+_U_CALLRAM2:
+        exx
+        ex      af,af'
+
+        pop     ix
+        ld      e,(ix+1)        ;Segment number
+        ld      d,(ix)  ;Slot and entry point number
+        dec     ix
+        dec     ix
+        push    ix
+        ld_iyl_e
+
+        ld      a,d
+        and     00111111b
+        ld      b,a
+        add     a,a
+        add     a,b     ;A = Address index * 3
+        ld      l,a
+        ld      h,40h
+        push    hl
+        pop     ix      ;IX = Address to call
+
+        ld      a,d
+        and     11000000b
+        rlca
+        rlca
+        rlca            ;A = Mapper table index * 8
+        rlca
+        rlca
+        ld      l,a
+        ld      h,0
+        ld      bc,(MAP_TAB##)
+        add     hl,bc
+        ld      a,(hl)  ;A = Slot to call
+        ld_iyh_a
+
+        ex      af,af'
+        exx
+        inc     sp
+        inc     sp
+        jr      _U_CALLRAM
 ;
 ;-----------------------------------------------------------------------------
 ;
@@ -2061,11 +2187,11 @@ P3_OFFSET_TAB:
 		defw	_PUT_P3
 		defw	_GET_P3
 
-		defw	_ALL_BK
-		defw	_FR_BK
-;
-		dw	0
-		dw	0
+		defw	_U_CALLRAM
+		defw	_U_READRAM
+        defw	_U_CALLRAM2
+		defw	_U_WRITERAM
+        dw 0
 ;
 ;	----------------------------------------
 ;

--- a/source/kernel/bank1/mapinit.mac
+++ b/source/kernel/bank1/mapinit.mac
@@ -724,18 +724,32 @@ MAPBIO3:
 
 		;Need to push EXACTLY these registers and in this order,
 		;since CHK_DEV changes the pushed values
-		push	de
-		push	af
-		call	CHK_DEV
-		pop	af
-		pop	de
 		exx
 		set	0,d
 		exx
+		push	de
+		push	af
+		call	CHK_DEV
+        exx
+        ex af,af'
+        bit 0,d
+        jr z,MAPB_DONT_CALL_OLD
+
+        ex af,af'   ;D'=0 at return: must call old hook with original registers
+        exx    
+		pop	af
+		pop	de
 		ret
+
+MAPB_DONT_CALL_OLD:
+        pop af      ;D'=1 at return: don't call old hook, keep returned registers
+        pop af
+        ex af,af'
+        exx
+        ret
 ;
 
-EXB_NEX:	;WIP...
+EXB_NEX:
 ;
 ;   Call the EXTBIO routine of Nextor kernels other than the master one
 ;   Out: D'=1 if system hook must be called, 0 otherwise
@@ -831,12 +845,38 @@ EXB_RAM_END:
 
 CHK_DEV:	ld	a,d
 		or	e
-		jr	nz,CHK_MAPDEV
+		jr	nz,CHK_UNAPI
 ;
 BROADCAST_BIO:	ld	a,MAP_DEV	;Build device number table function.
 		call	EXTWRT		;+0 set our device number
-		jp	EXTWRT		;+1 reserved field
+		call	EXTWRT		;+1 reserved field
+        jp RESET_EXX_D
 ;
+CHK_UNAPI:
+        ld  a,d
+        cp  22h
+        jr  nz,CHK_MAPDEV
+        ld  a,e
+        cp  22h
+        jr  nz,CHK_MAPDEV
+
+        ld  a,h
+        or  l
+        ret nz
+
+        pop de
+        pop af
+        cp 0FFh
+        push af
+        push de
+        ld de,2222h
+        ret nz
+
+        ld hl,MAP_VECT##+30h
+        ld bc,0
+        ld a,4  ;Number of RAM helper compatible routines
+        jp  RESET_EXX_D
+
 CHK_MAPDEV:	ld	a,d
 		cp	MAP_DEV		;Mapper device?
 		ret	nz
@@ -871,7 +911,8 @@ MAPBIO_0:	push	hl		;Build table function.
 		call	EXTWRT		;+4 set number of available segments
 		call	EXTWRT		;+5 reserved field
 		call	EXTWRT		;+6 reserved field
-		jp	EXTWRT		;+7 reserved field
+		call	EXTWRT		;+7 reserved field
+        jp RESET_EXX_D
 ;
 MAPBIO_1:	pop	de
 		pop	af		;Pop off saved AF
@@ -879,7 +920,7 @@ MAPBIO_1:	pop	de
 		ld	a,(hl)
 		push	af
 		push	de
-		ret
+		jp RESET_EXX_D
 ;
 MAPBIO_2:	pop	de
 		pop	af		;Pop off saved AF
@@ -892,7 +933,7 @@ MAPBIO_2:	pop	de
 		ld	hl,MAP_VECT##	;HL = address of jump vector
 		push	af
 		push	de
-		ret
+		jp RESET_EXX_D
 ;
 ;	Fill the table entry B:HL with [A], then advance HL.
 ;
@@ -906,6 +947,12 @@ EXTWRT:		push	bc
 		inc	hl
 		xor	a
 		ret
+
+RESET_EXX_D:
+    exx
+    res 0,d
+    exx
+    ret
 
 
 ; Returns NZ for superturbo mode, Z otherwise

--- a/source/kernel/bank4/bkalloc.mac
+++ b/source/kernel/bank4/bkalloc.mac
@@ -7,6 +7,10 @@
 	INCLUDE	CONST.INC
 ;
 
+;WARNING: These routines are no longer part of Nextor as of v2.1.0.
+;They are kept here for reference, so that applications can incorporate them
+;as part of their own code if necessary.
+
 	const	BK_PTR,0BFFEh
 
 ;-----------------------------------------------------------------------------

--- a/source/kernel/bank4/jump.mac
+++ b/source/kernel/bank4/jump.mac
@@ -38,9 +38,6 @@ jentry	macro	name
 	jentry	F_RDBLK
 	jentry	F_WRBLK
 
-	jentry	ALL_BK
-	jentry	FR_BK
-
 	jentry	F_GPART
 	jentry	GDRIVER
 	jentry	AUTODRV

--- a/source/kernel/compile.bat
+++ b/source/kernel/compile.bat
@@ -115,8 +115,8 @@ copy ..\data.rel
 copy ..\chgbnk.rel
 copy ..\bank2\b2labels.inc
 copy ..\bank0\b0labels.inc
-for %%A in (B4,JUMP,ENV,CPM,BKALLOC,PARTIT,RAMDRV,TIME,SEG,MISC) do cpm32 M80 =%%A
-cpm32 L80 /P:40FF,CODES,KVAR,DATA,B4,JUMP,ENV,CPM,BKALLOC,PARTIT,RAMDRV,TIME,SEG,MISC,/p:7fd0,chgbnk,B4/N/X/Y/E
+for %%A in (B4,JUMP,ENV,CPM,PARTIT,RAMDRV,TIME,SEG,MISC) do cpm32 M80 =%%A
+cpm32 L80 /P:40FF,CODES,KVAR,DATA,B4,JUMP,ENV,CPM,PARTIT,RAMDRV,TIME,SEG,MISC,/p:7fd0,chgbnk,B4/N/X/Y/E
 hex2bin -s 4000 b4.hex
 ..\SymToEqus b4.sym b4rdlabs.inc "R4_[1-9]"
 for %%A in (RAMDRVH) do cpm32 M80 =%%A

--- a/source/kernel/data.mac
+++ b/source/kernel/data.mac
@@ -106,11 +106,10 @@ ram_ad	defl	DATABASE
 	var3	PUT_P3		; /
 	var3	GET_P3		;/
 
-	;var3	ALL_BK		;Assembler complaints if these are defined (?)
-	;var3	FR_BK
-	;spare	6
-;
-	spare	12		;For future expansion
+    var3    CALL_MAP    ;UNAPI RAM helper compliant routines
+    var3    RD_MAP
+    var3    CALL_MAPI
+    var3    WR_MAP
 ;
 	var1	CUR_DRV		;Current logical drive (1=A:)
 	var2	DTA_ADDR,F23D	;DMAADD used by MSXDOS1.SYS - can not move.
@@ -485,9 +484,6 @@ ram_ad	defl	4100h
 	var3	F_SETRND
 	var3	F_RDBLK
 	var3	F_WRBLK
-
-	var3	ALL_BK
-	var3	FR_BK
 
 	var3	F_GPART
 	var3	GDRIVER

--- a/source/kernel/macros.inc
+++ b/source/kernel/macros.inc
@@ -28,6 +28,11 @@ ld_iyl_a	macro
 	ld	l,a
 	endm
 
+ld_iyl_e	macro
+	db	0FDh
+	ld	l,e
+	endm
+
 ld_iyh_b	macro
 	db	0FDh
 	ld	h,b


### PR DESCRIPTION
This pull request extends the mapper support routines with four new routines:

* `CALLRAM`: call a routine in another slot and segment, pass parameters in registers
* `READRAM`: read a byte from an address in a slot+segment combination
* `CALLRAM2`: call a routine in another slot and segment, pass parameters in stack
* `WRITERAM`: write a byte to an address in a slot+segment combination

The first three are compatible with [the UNAPI RAM Helper](https://github.com/Konamiman/MSX-UNAPI-specification/blob/master/docs/MSX%20UNAPI%20specification%201.1.md#4-the-ram-helper), including the extended BIOS based detection mechanism.

### WARNING: BREAKING CHANGE

The entry points for these routines go right after `GET_P3` in the jump table for the mapper support routines. In previous versions this area contained entry points for `ALL_BK` and `FR_BK`, which were routines for simple "malloc" style block allocation. There two routines have been removed from Nextor, but their source file (`source/kernel/bank4/bkalloc.mac`) has been left in place so that it can be examined and reused in application programs if necessary.