### PR TITLE
Fix calculation of cluster amount for FAT16 filesystems in FDISK

### DIFF
--- a/source/kernel/bank5/fdisk2.c
+++ b/source/kernel/bank5/fdisk2.c
@@ -413,12 +413,9 @@ int CalculateFatFileSystemParametersFat16(ulong fileSystemSizeInK, dosFilesystem
 
 	dataSectorsCount = (fileSystemSizeInK * 2) - (FAT16_ROOT_DIR_ENTRIES / DIR_ENTRIES_PER_SECTOR) - 1;
 	clusterCount = dataSectorsCount >> sectorsPerClusterPower;
-	sectorsPerFat = clusterCount + 2;
+	sectorsPerFat = (clusterCount + 2) >> 8;
 
-	if((sectorsPerFat & 0x3FF) == 0) {
-		sectorsPerFat >>= 8;
-	} else {
-		sectorsPerFat >>= 8;
+	if(((clusterCount + 2) & 0x3FF) != 0) {
 		sectorsPerFat++;
 	}
 


### PR DESCRIPTION
The routine that calculates the amount of clusters for a new FAT16 filesystem in FDSIK has a bug that appears when creating a filesystem with a maximum amount of clusters possible: a 16-bit variable overflows and turns into 0 when it should actually be 65536.

This causes the sector count in the boot sector to be higher than the actual size of the filesystem, and thus when writing to an almost full partition a "Disk error writing" error may appear if this is the only partition on the device or the last one. If there are more partitions after the one being written to, those could be overwritten.

This commit fixes this by adding an intermediate calculation that prevents the variable from overflowing.

### Fixing existing partitions

A filesystem is at fault if the "big sector count" field in its boot sector (at offset 20h) is higher than the partition size as declared in its partition table entry. Below you can see an example: the partition size is in yellow and the bad sector count is in red.

To fix, it's enough to set the sector count as equal to the partition size.

If partitions aren't fixed it's recommended not to fill them to their maximum capacity, leave about 1MB free to be safe.

![image](https://user-images.githubusercontent.com/937723/90908595-ddae9700-e3d4-11ea-904e-9e1b5bf1959b.png)
