### PR TITLE
Move UD_ACLU to the end of the unit descriptor

### DIFF
--- a/source/kernel/bank2/val.mac
+++ b/source/kernel/bank2/val.mac
@@ -1852,7 +1852,7 @@ endif
 ; Assumes:      UPB_DIRT=UPB_VOLID+6       UPB_ID=UPB_DIRT+1
 ;		  (UD_CMSK, UD_CSHFT, UD_RES, UD_NFAT, UD_ODE, UD_WDS
 ;		   UD_SFAT, UD_SDIR, UD_SDAT, UD_NCLU, UD_DIRT, UD_ID,
-;		   UD_MBYTE and UD_ACLU) must all be sequential.
+;		   and UD_MBYTE) must all be sequential.
 ;
 ;
 		call	_NEW_UPB
@@ -2157,9 +2157,12 @@ upb_dos220:
 						; from UPB to unit descriptor
         ld	(hl),a
 
-		inc hl	  ;Initialize next cluster to check for allocation to 2
-		ld (hl),1 ;(it's stored as value-1)
-		inc hl
+		pop hl
+		push hl
+		ld bc,UD_ACLU##
+		add hl,bc  
+		ld (hl),1     ;Initialize next cluster to check for allocation to 2
+		inc hl        ;(it's stored as value-1)
 		ld (hl),0
 
 		pop	hl

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -193,8 +193,6 @@ size	macro	name
 	field	4,UD_ID		;Current volume ID
 	field	1,UD_MBYTE	;Media descriptor byte
 
-	field   2,UD_ACLU	;Next cluster to check for allocation -1
-;
 	field	2,UD_CDIR	;First cluster of current directory
 				;  -ve   => root directory
 				;  0000h => cluster not known
@@ -209,6 +207,8 @@ size	macro	name
                         ;(for device-based drivers this is only used if the driver
 						; provides configuration, in order to get the default mapping
 						; for the drive)
+	field   2,UD_ACLU	;Next cluster to check for allocation -1
+
 ;
 	;--- Extra fields used when mounting files
 	;    This extra space should NOT be allocated unless a file is mounted to the drive


### PR DESCRIPTION
The improvement of the cluster chain allocation process performance (https://github.com/Konamiman/Nextor/pull/68, from v2.1.1 alpha 1) introduced a new unit descriptor field, `UD_ACLU`, in the middle of the unit descriptor (between `UD_MBYTE` and `UD_CDIR`). This caused severe problems when writing data (weird errors, computer crashes, even data corruption) because somewhere in the kernel there's code that assumed that these fields are stored consecutively in memory.

The fix consists of moving `UD_ACLU` to the end of the unit descriptor.