### PR TITLE
Change version to 3.0.0 alpha 1 and adjust BASIC message

### DIFF
--- a/source/kernel/bank0/dskbasic.mac
+++ b/source/kernel/bank0/dskbasic.mac
@@ -24,14 +24,6 @@ DEBUG	equ	OFF		;check for internal error
 
 NEWSTT	equ	04601h
 
-	public	BASVER,BASV_HI,BASV_LO
-BASVER	equ	2
-BASV_HI	equ	1
-ifdef VER890508
-BASV_LO	equ	0
-else
-BASV_LO	equ	0
-endif
 ;
 ;	MACRO
 ;

--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -175,9 +175,10 @@ DOSV0::
 	defb	0
 ;
 _$DSKBASIC::
-	defb	 "Nextor BASIC version ", BASVER##+"0"
-	defb	 ".", BASV_HI##+"0", BASV_LO##+"0"
-	INCLUDE betainfo.mac
+	defb	 "Nextor "
+	defb	NXTVER##+"0", ".", NXTV_HI##+"0" 
+	defb    ".", NXTV_LO##+"0"
+	defb     " BASIC"
 	defb	 0
 ;
 ;===== start mod DOS2.50 (change Copyright string)

--- a/source/kernel/compile.bat
+++ b/source/kernel/compile.bat
@@ -178,8 +178,8 @@ dd if=bank5\fdisk.dat of=dos250ba.dat bs=1 count=16000 seek=82176
 dd if=bank5\fdisk2.dat of=dos250ba.dat bs=1 count=8000 seek=98560
 copy bank4\b4rd.bin
 dd if=b4rd.bin of=dos250ba.dat bs=1 count=15 seek=65664
-copy dos250ba.dat Nextor-2.1.0.base.dat
-copy dos250ba.dat ..\..\bin\kernels\Nextor-2.1.0.base.dat
+copy dos250ba.dat Nextor-3.0.0-alpha1.base.dat
+copy dos250ba.dat ..\..\bin\kernels\Nextor-3.0.0-alpha1.base.dat
 
 :drivers
 
@@ -215,8 +215,8 @@ cpm32 L80 /P:7fd0,CHGBNK,CHGBNK/N/X/Y/E
 hex2bin -s 4000 driver.hex
 hex2bin -s 7FD0 CHGBNK.hex
 
-..\..\..\..\wintools\mknexrom  ..\..\Nextor-2.1.0.base.dat Nextor-2.1.0.%%~nc.ROM /d:driver.bin /m:chgbnk.bin
-copy Nextor-2.1.0.%%~nc.ROM ..\..\..\..\bin\kernels
+..\..\..\..\wintools\mknexrom  ..\..\Nextor-3.0.0-alpha1.base.dat Nextor-3.0.0-alpha1.%%~nc.ROM /d:driver.bin /m:chgbnk.bin
+copy Nextor-3.0.0-alpha1.%%~nc.ROM ..\..\..\..\bin\kernels
 del b6.mac
 del *.rom
 cd ..
@@ -230,15 +230,15 @@ echo ***
 echo .
 
 cd MegaFlashRomSD
-..\..\..\..\wintools\mknexrom ..\..\Nextor-2.1.0.base.dat nextor2.rom /d:driver-1slot.dat /m:Mapper.ASCII8.bin
-copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-2.1.0.MegaFlashSDSCC.1-slot.ROM
+..\..\..\..\wintools\mknexrom ..\..\Nextor-3.0.0-alpha1.base.dat nextor2.rom /d:driver-1slot.dat /m:Mapper.ASCII8.bin
+copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.MegaFlashSDSCC.1-slot.ROM
 sjasm makerecoverykernel.asm kernel.dat
-copy kernel.dat ..\..\..\..\bin\kernels\Nextor-2.1.0.MegaFlashSDSCC.1-slot.Recovery.ROM
+copy kernel.dat ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.MegaFlashSDSCC.1-slot.Recovery.ROM
 del nextor2.rom
-..\..\..\..\wintools\mknexrom ..\..\Nextor-2.1.0.base.dat nextor2.rom /d:driver-2slots.dat /m:Mapper.ASCII8.bin
-copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-2.1.0.MegaFlashSDSCC.2-slots.ROM
+..\..\..\..\wintools\mknexrom ..\..\Nextor-3.0.0-alpha1.base.dat nextor2.rom /d:driver-2slots.dat /m:Mapper.ASCII8.bin
+copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.MegaFlashSDSCC.2-slots.ROM
 sjasm makerecoverykernel.asm kernel.dat
-copy kernel.dat ..\..\..\..\bin\kernels\Nextor-2.1.0.MegaFlashSDSCC.2-slots.Recovery.ROM
+copy kernel.dat ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.MegaFlashSDSCC.2-slots.Recovery.ROM
 cd ..
 
 echo .
@@ -249,11 +249,11 @@ echo .
 
 cd SunriseIDE
 
-del ..\..\..\..\bin\kernels\Nextor-2.1.0.SunriseIDE.emulators.ROM
-ren ..\..\..\..\bin\kernels\Nextor-2.1.0.SunriseIDE.ROM Nextor-2.1.0.SunriseIDE.emulators.ROM 
+del ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.SunriseIDE.emulators.ROM
+ren ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.SunriseIDE.ROM Nextor-3.0.0-alpha1.SunriseIDE.emulators.ROM 
 sjasm -c sunride.asm driver.bin
-..\..\..\..\wintools\mknexrom ..\..\Nextor-2.1.0.base.dat nextor2.rom /d:driver.bin /m:chgbnk.bin
-copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-2.1.0.SunriseIDE.ROM
+..\..\..\..\wintools\mknexrom ..\..\Nextor-3.0.0-alpha1.base.dat nextor2.rom /d:driver.bin /m:chgbnk.bin
+copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.SunriseIDE.ROM
 :okide
 cd ..
 
@@ -265,8 +265,8 @@ echo .
 
 cd Flashjacks
 sjasm flashjacks.asm driver.bin
-..\..\..\..\wintools\mknexrom ..\..\Nextor-2.1.0.base.dat nextor2.rom /d:driver.bin /m:chgbnk.dat
-copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-2.1.0.Flashjacks.ROM
+..\..\..\..\wintools\mknexrom ..\..\Nextor-3.0.0-alpha1.base.dat nextor2.rom /d:driver.bin /m:chgbnk.dat
+copy nextor2.rom ..\..\..\..\bin\kernels\Nextor-3.0.0-alpha1.Flashjacks.ROM
 cd ..
 
 echo .

--- a/source/kernel/condasm.inc
+++ b/source/kernel/condasm.inc
@@ -8,7 +8,7 @@ HYBRID	equ	-1		;DOS1/DOS2 hybrid system
 STURBO	equ	-1		;support super turbo mode (for MSXturboR)
 BUILTIN	equ	-1		;built-in system
 
-ALPHA	equ	0		;Level of Alpha release (0: no alpha)
+ALPHA	equ	1		;Level of Alpha release (0: no alpha)
 ALPHAL	equ	""		;Letter after the Alpha release number, or empty
 BETA	equ	0		;Level of Beta release (0: no beta)
 RC	equ	0		;Level of RC (0: no RC)

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -23,8 +23,8 @@
 	const	DOSVER,2	;Major version number
 	const	DOSV_HI,3	;Minor version number, high nybble
 	const	DOSV_LO,1	;Minor version number, low nybble
-	const	NXTVER,2
-	const	NXTV_HI,1
+	const	NXTVER,3
+	const	NXTV_HI,0
 	const	NXTV_LO,0
 ;===== end mod DOS2.50
 ;


### PR DESCRIPTION
* Change Nextor kernel version to 3.0.0 alpha 1
* Adjust `kernel/compile.bat` to generate the kernel files appropriately named.
* Change the BASIC startup sting to simply `Nextor <kernel version> BASIC`