### PR TITLE
GPART: Fix for issue where IX and IY are not returned to caller

### DIFF
--- a/source/command/msxdos/sys.mac
+++ b/source/command/msxdos/sys.mac
@@ -1017,6 +1017,23 @@ zstr_slow:
 	;LD	E,RELEASE##+(RELEASE##/256)*16
 	ret
 
+@GPART:	; RETURN CORRECT IX, IY VALUES BY WALKING AND MODIFYING STACK
+	EXX
+	POP	HL		; Get return address, and pop off the saved
+	POP	DE		;   values of IX and IY.
+	POP	DE
+	PUSH	HL
+	EXX
+	CALL	KBDOS		; Call KBDOS, which returns stuff in IY & IX.
+	EXX			; Save returned values.
+	POP	HL		; Get the return address again.
+	PUSH	IX		; Push new 'saved' IX and IY values.
+	PUSH	IY
+	PUSH	HL
+	EXX
+	RET
+
+
 FUNC_WITH_IXIY:
 	EXX
 	pop	bc
@@ -1036,7 +1053,6 @@ FUNC_WITH_IXIY:
 	push	bc
 	EXX
 	RET
-
 ;
 ;
 ;------------------------------------------------------------------------------
@@ -1263,7 +1279,6 @@ _KBSDE:	LD	DE,BUFF1	; DE -> buffer containing FIB or string.
 @RALLOC:
 @DSPACE:
 @LOCK:
-@GPART:
 @Z80MODE:
 
 ;

--- a/source/kernel/bank0/bdos.mac
+++ b/source/kernel/bank0/bdos.mac
@@ -935,7 +935,7 @@ STRCPY:	LD	A,(HL)		;Get character from string.
 	ld	bc,64
 	ldir
 	pop	hl
-	ret	
+	ret
 ;
 ;------------------------------------------------------------------------------
 ;


### PR DESCRIPTION
Hi,

I stumbled on something that I am not 100% sure i fully understand. 

I was trying to use the GPART function, and noticed that the, sector count, was not being returned in the IX:IY register, within my application.  After much digging and barely understandings, i think i found the cause. 

I noticed that the other functions that return values in the index registers, use `FUNC_WITH_IXIY` code.  This function walks the stacks and replaces the stored IX, IY registers - expecting a certain stack depth.  I thought that GPART just needed to be mapped in the same way.  Alas, not quite, as the stack depth for when I call the GPART function is different (IX and IY are the first items after the return address).

So i made a similar block of code, especially for GPART, and my application now get the right value.

I also understand that GPART is currently used with the embedded fdisk code in the kernel .  I am not sure if I have screwed that up - would not be surprised.  Your insights would be welcomed.

Cheers
Dean