### PR TITLE
Fix: DE registers corrupted by extended BIOS handling code

### DIFF
--- a/source/kernel/bank1/mapinit.mac
+++ b/source/kernel/bank1/mapinit.mac
@@ -687,6 +687,12 @@ MAPBIO::
 ;   For other values of D, the EXTBIO hook on the driver bank is called with D'=1.
 ;   This must return D'=1 if old hook must be called, D'=0 otherwise.
 
+		push de	;DE must always be preserved
+		call MAPBDO
+		pop de
+		ret
+
+MAPBDO:
 		exx
 		set	0,d
 		exx


### PR DESCRIPTION
The DE register pair must always be preserved when handling the EXTBIO hook, but it was being corrupter. With this fix the register pair will always be preserved, even if a driver has EXTBIO processing code that corrupts it.

Closes #87.