### PR TITLE
Fix: incorrect setting of UD_ACLU when freeing a FAT chain

### DIFF
--- a/source/kernel/bank2/fat.mac
+++ b/source/kernel/bank2/fat.mac
@@ -898,8 +898,11 @@ zero_dsec_loop:	ld	(hl),c			; the data area of buffer
 		dec de          ;DE = new value
 		or a
 		sbc hl,de       ;HL = current value - new value, Cy=1 if new > current
-		call nc,ACLU_SET
 		pop hl          ;Restore address of unit descriptor
+		ret c
+		ld de,(FAT_CHAIN##)
+		dec de
+		call ACLU_SET
 		ret
 
 frchlp3:

--- a/source/kernel/bank2/fat.mac
+++ b/source/kernel/bank2/fat.mac
@@ -902,8 +902,7 @@ zero_dsec_loop:	ld	(hl),c			; the data area of buffer
 		ret c
 		ld de,(FAT_CHAIN##)
 		dec de
-		call ACLU_SET
-		ret
+		jp ACLU_SET
 
 frchlp3:
 		push hl			;Preserve address of unit descriptor


### PR DESCRIPTION
Nextor 2.1.1 Alpha 1 introduced a new mechanism to improve the performance of cluster chain allocation in large drives, by caching the value of the smallest free cluster number (https://github.com/Konamiman/Nextor/pull/68 and https://github.com/Konamiman/Nextor/pull/72).

There's however a problem. When freeing a FAT chain (while deleting a file) the value of the cached value in the unit descriptor of the drive is updated to the smallest cluster number freed, but the code doing this has a bug and instead, a random memory address is modified; for small cluster numbers this means that the Nextor code itself is overwritten and this caused the computer to crash. 

This pull request fixes this problem. To test the fix, you can use an empty floppy/storage device (or an equivalent disk image in an emulator); creating and deleting a few files will end up causing a computer crash in Nextor 2.1.1 beta 1, which shouldn't happen when this fix is applied.
