### PR TITLE
Add the CALL SYSTEM2 command in BASIC

### DIFF
--- a/docs/Nextor 2.1 User Manual.md
+++ b/docs/Nextor 2.1 User Manual.md
@@ -108,6 +108,8 @@
 
 [3.6.11. The CALL USR command](#3611-the-call-usr-command)
 
+[3.6.12 The CALL SYSTEM2 command](#3611-the-call-system2-command)
+
 [3.7. New BASIC error codes](#37-new-basic-error-codes)
 
 [3.8. Mounting files](#38-mounting-files)
@@ -357,6 +359,8 @@ Nextor consists of the following components:
 **Note:** two variants of the NEXTOR.SYS file exist. See _[4.3. Reduced NEXTOR.SYS without Japanese error messages](#43-reduced-nextorsys-without-japanese-error-messages)_.
 
 **Note:** starting with Nextor 2.1.0 beta 2, the kernel will try to load MSXDOS2.SYS if NEXTOR.SYS is not found. However in this case the Nextor command line tools won't work.
+
+**Note:** starting with Nextor 2.1.0 beta 2, [the `CALL SYSTEM2` command](#3611-the-call-system2-command) can be used in BASIC to force a reboot in the DOS environment using MSXDOS2.SYS, even if NEXTOR.SYS exists.
 
 In order to boot in the MSX-DOS 1 prompt, you need the usual MSXDOS.SYS and COMMAND.COM files. Also, if you have just the kernel and no NEXTOR.SYS or MSXDOS.SYS files, Nextor will boot in the BASIC prompt (running AUTOEXEC.BAS if present).
 
@@ -920,6 +924,13 @@ Here is a simple BASIC program to test the CALL USR command. Change the register
 150 PRINT "IX=&H";HEX$(R(4))
 160 PRINT "IY=&H";HEX$(R(5))
 ````
+
+#### 3.6.12 The CALL SYSTEM2 command
+
+Nextor 2.1.1 introduced a new `CALL SYSTEM2` command. This command works the same as `CALL SYSTEM`, but will always load MSXDOS2.SYS, even if a file named NEXTOR.SYS exists. This can be useful to get back some TPA space for applications, since MSXDOS2.SYS is smaller than NEXTOR.SYS.
+
+Note however that the new function calls introduced by Nextor won't work if NEXTOR.SYS isn't loaded, this implies that the Nextor-specific command line tools (e.g. `MAPDRV.COM`) won't work if the DOS environment is entered via `CALL SYSTEM2` command.
+
 
 ### 3.7. New BASIC error codes
 

--- a/source/kernel/bank0/dosboot.mac
+++ b/source/kernel/bank0/dosboot.mac
@@ -294,12 +294,19 @@ NOBOOT:
 		jr	z,msxdos_fail
 ;
 retry_dos:
+		ld a,(MFLAGS##)
+		bit 7,a	;SYST2
+		res 7,a
+		ld (MFLAGS##),a
+		jr nz,retry_dos2
+retry_dos_go:
 		ld	de,BOOT_NAME    ;Try to open the "NEXTOR.SYS"
 		xor	a               ;file on the default drive.
 		ld	c,_OPEN##
 		call	BOOT_BDOS
         jr z,msxdos_bootok
 
+retry_dos2:
         ld	de,OLD_BOOT_NAME    ;Fallback to try "MSXDOS.SYS"
 		xor	a
 		ld	c,_OPEN##

--- a/source/kernel/bank0/dskbasic.mac
+++ b/source/kernel/bank0/dskbasic.mac
@@ -397,6 +397,8 @@ ABORT:
 ;	Table of expanded statements
 ;
 COMMAND:
+	defb	'SYSTEM2',0
+	defw	SYSTEM2
 	defb	'SYSTEM',0
 	defw	SYSTEM
 	defb	'FORMAT',0
@@ -437,6 +439,12 @@ COMMAND:
 ;
 ;	_SYSTEM[("<command_string>")]
 ;
+SYSTEM2:
+	push hl
+	ld hl,MFLAGS##
+	set 7,(hl)	;SYST2
+	pop hl
+
 SYSTEM:
 	ld	de,CMDTMP	; assume end of statement
 	jr	z,SYSTEM_NO_ARG	; good assumption

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -5300,6 +5300,7 @@ CNEXTOR_S:
 	db	"_MAPDRV()",13,10
 	db	"_MAPDRVL() *",13,10
 	db	"_USR()",13,10
+	db  "_SYSTEM2() - boot DOS using MSXDOS2.SYS",13,10
 	db	13,10
 	db	"Commands with * are not available",1
 	db	"in MSX-DOS 1 mode.",13,10

--- a/source/kernel/data.mac
+++ b/source/kernel/data.mac
@@ -218,6 +218,7 @@ ram_ad	defl	DATABASE
 	const	FASTOUT,0	;bit 0: set for fast STROUT
 	const	FIRSTLD,1	;bit 1: set while booting NEXTOR.SYS for the first time
 	const	ZALLOC,2	;bit 2: reduced alloc info mode becomes zero info mode
+	const   SYST2,7     ;Bit 7: force boot in MSXDOS2.SYS (temporary, reset after read)
 	spare	1		;Available for DOS 2
 ;
 	var2	BLDCHK


### PR DESCRIPTION
This new BASIC command works the same way as the old `CALL SYSTEM`, but it will always load `MSXDOS2.SYS` even if `NEXTOR.SYS` is available. This helps getting back some TPA memory, since `MSXDOS2.SYS` is smaller than `NEXTOR.SYS`, but at the expense of not being able to use the Nextor-exclusive function calls (so tools like e.g. `MAPDRV.COM` won't work).