### PR TITLE
Add a new KILLDSKIO environment variable

### DIFF
--- a/docs/Nextor 2.1 User Manual.md
+++ b/docs/Nextor 2.1 User Manual.md
@@ -42,6 +42,8 @@
 
 [2.13. File mounting and disk emulation mode](#213-file-mounting-and-disk-emulation-mode)
 
+[2.14. The KILLDSKIO environment variable](#214-the-killdskio-environment-variable)
+
 [3. Using Nextor](#3-using-nextor)
 
 [3.1. Installing Nextor](#31-installing-nextor)
@@ -338,6 +340,12 @@ Since version 2.1 Nextor allows to mount disk image files in two ways:
 * Botting normally and mounting a disk image file in a drive. See [3.8. Mounting files](#38-mounting-files).
 
 * Booting in disk emulation mode, so the system boots in MSX-DOS 1 mode and uses a set disk image files (one at a time) as the boot device. See [3.9. Disk emulation mode](#39-disk-emulation-mode).
+
+### 2.14. The KILLDSKIO environment variable
+
+Since version 2.1.1 Nextor provides a mechanism to disable the BASIC commands `DSKI$` and `DSKO$`, which gives 512 extra bytes of free memory for the BASIC environment. This is achieved by creating an environment variable named `KILLDSKIO` with a value of `ON` (case-insensitive).
+
+Note that when `DSKI$` and `DSKO$` are disabled in this way the `DIRBUF` variable (&HF351), which holds the address of the 512 byte buffer where these commands read and write sectors, will have the same value as `SECBUF` (&HF34D), which is a generic sector buffer used internally by Nextor; and the same goes for `PATHNAM` (&HF33B), a buffer used by BASIC to parse pathnames for commands like `FILES`. This shouldn't be a problem in most cases, but for robustness it's recommended to use this feature only when that extra memory is abolutely necessary.
 
 
 ## 3. Using Nextor
@@ -1103,6 +1111,10 @@ This section contains the change history for the different versions of Nextor. C
 
 This list contains the changes for the 2.1 branch only. For the change history of the 2.0 branch see the _[Nextor 2.0 User Manual](../../../blob/v2.0/docs/Nextor%202.0%20User%20Manual.md#5-change-history)_ document.
 
+
+### 5.1. v2.1.1 beta 2
+
+- Introduced the 
 
 ### 5.1. v2.1.0 beta 2
 

--- a/source/kernel/bank0/dskbasic.mac
+++ b/source/kernel/bank0/dskbasic.mac
@@ -1924,6 +1924,15 @@ GET_HANDLE_0:
 	pop	hl
 	ret
 
+CHECK_DIRBUF:
+	push hl
+	ld hl,($DIRBUF)
+	ld a,h
+	or l
+	pop hl
+	jp z,JSNERR
+	ret
+
 if	1
 	subttl	DSKI$/DSKO$
 ;
@@ -1931,6 +1940,7 @@ if	1
 ;	DSKO$ <drive_number>,<sector_number>
 ;
 $HOOK	DSKI$
+	call CHECK_DIRBUF
 	call	REMHOK		;remove hook return
 	call	CHRGET		;skip over current token
 	SYNCHK	'('
@@ -1947,6 +1957,7 @@ $HOOK	DSKI$
 	jr	DSKO$1		;perform disk input
 ;
 $HOOK	DSKO$
+	call CHECK_DIRBUF
 	call	REMHOK		;remove hook return
 	call	GET_PARAM	;get drive and sector
 	call	CHRGOT		;end of statement?

--- a/source/kernel/bank0/dskbasic.mac
+++ b/source/kernel/bank0/dskbasic.mac
@@ -1924,13 +1924,10 @@ GET_HANDLE_0:
 	pop	hl
 	ret
 
-CHECK_DIRBUF:
-	push hl
-	ld hl,($DIRBUF)
-	ld a,h
-	or l
-	pop hl
-	jp z,JSNERR
+CHECK_KILLDSKIO:
+	ld a,(MFLAGS##)
+	and	16	;KILLD
+	jp nz,JSNERR
 	ret
 
 if	1
@@ -1940,7 +1937,7 @@ if	1
 ;	DSKO$ <drive_number>,<sector_number>
 ;
 $HOOK	DSKI$
-	call CHECK_DIRBUF
+	call CHECK_KILLDSKIO
 	call	REMHOK		;remove hook return
 	call	CHRGET		;skip over current token
 	SYNCHK	'('
@@ -1957,7 +1954,7 @@ $HOOK	DSKI$
 	jr	DSKO$1		;perform disk input
 ;
 $HOOK	DSKO$
-	call CHECK_DIRBUF
+	call CHECK_KILLDSKIO
 	call	REMHOK		;remove hook return
 	call	GET_PARAM	;get drive and sector
 	call	CHRGOT		;end of statement?

--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -1868,8 +1868,13 @@ SET_DISKBASIC::
 	ld	hl,DBABORT##
 	ld	(BREAKVECT##),hl
 ;
-	ld	bc,($MAXSEC##)	;Allocate sector buffer for DSKI$, DSKO$
+	ld a,(MFLAGS##)
+	and	16	;KILLD
+	ld hl,0
+	jr nz,SET_DIRBUF	;Allocate sector buffer for DSKI$, DSKO$
+	ld	bc,($MAXSEC##)	;unless KILLDSKIO env item is set
 	call	RESERVE_BASIC
+SET_DIRBUF:
 	ld	($DIRBUF##),hl
 if 0
 ;

--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -1870,7 +1870,7 @@ SET_DISKBASIC::
 ;
 	ld a,(MFLAGS##)
 	and	16	;KILLD
-	ld hl,0
+	ld hl,($SECBUF##)
 	jr nz,SET_DIRBUF	;Allocate sector buffer for DSKI$, DSKO$
 	ld	bc,($MAXSEC##)	;unless KILLDSKIO env item is set
 	call	RESERVE_BASIC

--- a/source/kernel/bank4/env.mac
+++ b/source/kernel/bank4/env.mac
@@ -135,7 +135,7 @@ check_duplicate:call	FIND_ENV_ITEM		;Look for a matching item
 		xor	a
 		ret				;Return with no error.
 
-	;Check for ZALLOC and ERRLANG
+	;Check for ZALLOC, KILLDSKIO and ERRLANG
 
 CHECK_SPECIAL:
 	push	hl	;Name
@@ -162,7 +162,37 @@ ZALLOC_OFF:
 
 ZALLOC_END:
 	ld	(MFLAGS##),a
+	jr CHKERRLANG_END
+
 CHKZALLOC_END:
+	pop de
+	pop hl
+	push hl
+	push de
+
+CHECK_KILLD:
+	ld	de,KILLD_S
+	call	COMPARE_ENV
+	jr	nz,CHKKILLD_END
+
+	pop	hl	;Value
+	push	hl
+	ld	de,ON_S
+	call	COMPARE_ENV
+	ld	a,(MFLAGS##)
+	jr	nz,KILLD_OFF
+
+KILLD_ON:
+	or	16
+	jr	KILLD_END
+
+KILLD_OFF:
+	and	255-16
+
+KILLD_END:
+	ld	(MFLAGS##),a
+	jr CHKERRLANG_END
+CHKKILLD_END:
 	pop	de
 	pop	hl
 	push	hl
@@ -195,6 +225,7 @@ CHKERRLANG_END:
 	ret
 
 ZALLOC_S:	db	"ZALLOC",0
+KILLD_S:	db  "KILLDSKIO",0
 ERRLANG_S:	db	"ERRLANG",0
 ON_S:	db	"ON",0
 EN_S:	db	"EN",0

--- a/source/kernel/data.mac
+++ b/source/kernel/data.mac
@@ -217,7 +217,10 @@ ram_ad	defl	DATABASE
 	var1	MFLAGS		;Miscellaneous flags
 	const	FASTOUT,0	;bit 0: set for fast STROUT
 	const	FIRSTLD,1	;bit 1: set while booting NEXTOR.SYS for the first time
-	const	ZALLOC,2	;bit 2: reduced alloc info mode becomes zero info mode
+	const	ZALLOC,2	;bit 2: reduced alloc info mode becomes zero info mode (SET ZALLOC ON)
+	const   ERRL,3      ;bit 3: always show error messages in English (SET ERRLANG ON)
+	const   KILLD,4		;bit 4: kill DSKI and DSKO BASIC commands (SET KILLDSKIO ON)
+	const   SYST2,7     ;Bit 7: force boot in MSXDOS2.SYS (temporary, reset after read)
 	spare	1		;Available for DOS 2
 ;
 	var2	BLDCHK


### PR DESCRIPTION
If an environment variable named `KILLDSKIO` exists with a value of `ON` (case insensitive) when the BASIC environment is started, the 512 byte buffer that is normally allocated as a sector buffer for the `DSKI$` and `DSKO$` commands won't be allocated, thus these 512 bytes will be gained back for BASIC programs. This implies that the `DSKI$` and `DSKO$` commands will be unavailable (they will throw "syntax error").

This may be useful to load memory-intensive BASIC programs, and compensates for the fact that Nextor allocates about 230 extra bytes in page 3 than MSX-DOS 2.

When this mechanism is used to disable `DSKI$` and `DSKO$` the `DIRBUF` variable (&HF351), which holds the address of the 512 byte buffer where these commands read and write sectors, will have the same value as `SECBUF` (&HF34D), which is a generic sector buffer used internally by Nextor; and the same goes for `PATHNAM` (&HF33B), a buffer used by BASIC to parse pathnames for commands like `FILES`. This shouldn't be a problem in most cases, but for robustness it's recommended to use this feature only when that extra memory is absolutely necessary.