### PR TITLE
Add "master device only" editions for the Sunrise IDE kernel ROMs

### DIFF
--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -31,7 +31,7 @@ endef
 ###  MAIN RULE  ###
 ###################
 
-all: base ide ide-emu ascii8 ascii16 mfrsd flashjacks ocm
+all: base ide ide-masteronly ide-emu ide-masteronly-emu ascii8 ascii16 mfrsd flashjacks ocm
 
 TOOLS := M80 L80 LIB80 objcopy sdcc mknexrom dd
 
@@ -74,6 +74,26 @@ drivers/SunriseIDE/sunride.BIN: \
 	sjasm -c drivers/SunriseIDE/sunride.asm drivers/SunriseIDE/sunride.BIN
 
 
+### Sunrise IDE, normal ROM, master device only
+
+ide-masteronly: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.ROM
+
+drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.ROM: \
+	nextor_base.dat \
+	drivers/SunriseIDE/sunride.masteronly.BIN \
+	drivers/SunriseIDE/CHGBNK.BIN
+
+	mknexrom nextor_base.dat $@ /d:drivers/SunriseIDE/sunride.masteronly.BIN /m:drivers/SunriseIDE/CHGBNK.BIN
+	$(call copy_to_bin,$@)
+
+drivers/SunriseIDE/sunride.masteronly.BIN: \
+	drivers/SunriseIDE/sunride.asm
+
+	sed 's/MASTER_ONLY equ 0/MASTER_ONLY equ 1/g' drivers/SunriseIDE/sunride.asm > drivers/SunriseIDE/sunride.masteronly.asm
+
+	sjasm -c drivers/SunriseIDE/sunride.masteronly.asm drivers/SunriseIDE/sunride.masteronly.BIN
+
+
 ### Sunrise IDE, ROM for emulators
 
 ide-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.emulators.ROM
@@ -93,6 +113,30 @@ drivers/SunriseIDE/DRIVER.BIN: \
 
 	M80 -w drivers/SunriseIDE -p ../.. =DRIVER
 	L80 -w drivers/SunriseIDE -p ../../ /P:4100,DRIVER,DRIVER/N/X/Y/E
+	$(call hex2bin,$(patsubst %.BIN,%,$@))
+
+
+### Sunrise IDE, ROM for emulators, master device only
+
+ide-masteronly-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.emulators.ROM
+
+drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.emulators.ROM: \
+	nextor_base.dat \
+	drivers/SunriseIDE/DRVMONLY.BIN \
+	drivers/SunriseIDE/CHGBNK.BIN \
+	256.bytes
+
+	cat 256.bytes drivers/SunriseIDE/DRVMONLY.BIN > drivers/SunriseIDE/_driver.BIN
+	mknexrom nextor_base.dat $@ /d:drivers/SunriseIDE/_driver.BIN /m:drivers/SunriseIDE/CHGBNK.BIN
+	$(call copy_to_bin,$@)
+
+drivers/SunriseIDE/DRVMONLY.BIN: \
+	drivers/SunriseIDE/driver.mac
+
+	sed 's/MASTER_ONLY equ 0/MASTER_ONLY equ 1/g' drivers/SunriseIDE/driver.mac > drivers/SunriseIDE/drvmonly.mac
+
+	M80 -w drivers/SunriseIDE -p ../.. =DRVMONLY
+	L80 -w drivers/SunriseIDE -p ../../ /P:4100,DRVMONLY,DRVMONLY/N/X/Y/E
 	$(call hex2bin,$(patsubst %.BIN,%,$@))
 
 

--- a/source/kernel/drivers/SunriseIDE/.gitignore
+++ b/source/kernel/drivers/SunriseIDE/.gitignore
@@ -1,0 +1,2 @@
+sunride.masteronly.asm
+drvmonly.mac

--- a/source/kernel/drivers/SunriseIDE/driver.mac
+++ b/source/kernel/drivers/SunriseIDE/driver.mac
@@ -7,6 +7,8 @@ DRV_START:
 
 TESTADD	equ	0F3F5h
 
+MASTER_ONLY equ 0
+
 ;-----------------------------------------------------------------------------
 ;
 ; Driver configuration constants
@@ -406,6 +408,9 @@ WAIT_RESET_END:
 	ld	a,1			;Flag the device
 	ld	(ix),a
 MASTER_CHECK1_END:
+
+if MASTER_ONLY eq 0
+
         ld      a,46			;Print dot
         call    CHPUT
 	
@@ -441,6 +446,8 @@ SLAVE_CHECK1_END:
 
 	ld      de,CRLF_S
         call    PRINT
+
+endif
 
 	;--- Get info and show the name for the MASTER
 
@@ -507,6 +514,8 @@ NODEV_MASTER:
 	call	PRINT
 	
 OK_MASTER:
+
+if MASTER_ONLY eq 0
 
 	;--- Get info and show the name for the SLAVE
 	
@@ -580,6 +589,8 @@ OK_SLAVE:
         xor     a
         ld      (IDE_DEVCTRL),a
 
+endif
+
 	jr	DRV_INIT_END
 
 INIT_NO_DEV:
@@ -592,8 +603,14 @@ INIT_NO_DEV:
 	call	PRINT
 	ld	de,NODEVS_S
 	call	PRINT
+
+if MASTER_ONLY eq 0
+
 	ld	de,SLAVE_S
 	call	PRINT
+
+endif
+
 	ld	de,NODEVS_S
 	call	PRINT
 	
@@ -1671,6 +1688,13 @@ CHECK_DEV_LUN:
 INFO_S:
 	db	"Sunrise IDE driver v"
 	db	VER_MAIN+"0",".",VER_SEC+"0",".",VER_REV+"0",13,10
+
+if MASTER_ONLY eq 1
+
+	db "Master device only edition",13,10
+
+endif
+
 	db	"(c) Konamiman  2009",13,10
 	db	"(c) Piter Punk 2014",13,10,13,10,0
 
@@ -1681,8 +1705,14 @@ NODEVS_S:
 	db	"Not found",13,10,0
 MASTER_S:
 	db	"Master device: ",0
+
+if MASTER_ONLY eq 0
+
 SLAVE_S:
 	db	"Slave device:  ",0
+
+endif
+
 CRLF_S:
 	db	13,10,0
 

--- a/source/kernel/drivers/SunriseIDE/sunride.asm
+++ b/source/kernel/drivers/SunriseIDE/sunride.asm
@@ -9,6 +9,8 @@
 	ds	4100h-$,0		; DRV_START must be at 4100h
 DRV_START:
 
+MASTER_ONLY equ 0
+
 TESTADD	equ	0F3F5h
 
 TEMP_WORK equ 0C000h
@@ -551,6 +553,8 @@ DRV_INIT:
 	jr	z,INIT_MASTERFAIL	; Finish DEV_INIT
 
 .chkslave:
+	if MASTER_ONLY = 0
+
 	ld	de,SLAVE_S
 	ld	(TEMP_WORK+WRKTEMP.pDEVMSG),de
 	call	PRINT
@@ -571,6 +575,8 @@ DRV_INIT:
 	ld	a,M_DEV			; Select SLAVE
 	call	DETDEV
 	pop	ix
+
+	endif
 
 	; Reset all devices to finish
 END_DETECT:
@@ -3251,6 +3257,13 @@ INICHKSTOP:
 INFO_S:
 	db	13,"Sunrise compatible IDE driver v",27,'J'
 	db	VER_MAIN+$30,'.',VER_SEC+$30,'.',VER_REV+$30
+
+	if MASTER_ONLY = 1
+
+	db 13,10,"Master device only edition"
+
+	endif
+
 CRLF_S:	db	13,10,0
 COPYRIGHT_S:
 	db	"(c) 2009 Konamiman",13,10
@@ -3271,8 +3284,13 @@ INIT_S:
 	db	13,"Initializing : ",27,'J',0
 MASTER_S:
 	db	13,"Master device: ",27,'J',0
+
+	if MASTER_ONLY = 0
+
 SLAVE_S:
 	db	13,"Slave device : ",27,'J',0
+
+	endif
 
 OK_S:	db	"Ok",13,10,0
 ERROR_S:

--- a/source/kernel/drivers/SunriseIDE/sunride.asm
+++ b/source/kernel/drivers/SunriseIDE/sunride.asm
@@ -13,7 +13,9 @@ MASTER_ONLY equ 0
 
 TESTADD	equ	0F3F5h
 
-TEMP_WORK equ 0C000h
+;A few Panasonic FS machines uses the area around C000-C400 at boot time,
+;so better to not use C000; C400 will do.
+TEMP_WORK equ 0C400h
 
 ;-----------------------------------------------------------------------------
 ;


### PR DESCRIPTION
This pull request modifies `source/kernel/Makefile`, `source/kernel/drivers/SunriseIDE/driver.mac` and `source/kernel/drivers/SunriseIDE/sunride.asm` so that two additional ROM files are generated:

* Nextor-(version).SunriseIDE.MasterOnly.ROM
* Nextor-(version).SunriseIDE.MasterOnly.emulators.ROM

These versions work as the existing ones, except that slave device detection will be skipped. Users of Carnivore2 should use Nextor-(version).SunriseIDE.MasterOnly.ROM.

Additionally, the temporary work area of the `sunride.asm` driver is changed from C000h to C400h, [to prevent conflicts with the Panasonic FS machines](https://github.com/Konamiman/Nextor/pull/105#issuecomment-1174469950).