### PR TITLE
Fix: FDISK not working on korean MSX computers

### DIFF
--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -463,6 +463,7 @@ bank6/B6.HEX: \
 bank5/fdisk.dat bank5/fdisk2.dat: \
 	bank5/fdisk_crt0.rel \
 	bank5/fdisk.h \
+	bank5/fdisk.c \
 	$(patsubst %.dat,%.c,$@) \
 	bank5/drivercall.h \
 	bank5/drivercall.c \

--- a/source/kernel/bank5/fdisk.c
+++ b/source/kernel/bank5/fdisk.c
@@ -1591,9 +1591,19 @@ void InitializeWorkingScreen(char* header)
 void PrintRuler()
 {
 	int i;
+	byte width;
+	
+	// "Hack" for korean MSX computers that do weird things
+	// when printing a character at the last column of the screen
+	if(*((byte*)H_CHPH) != 0xC9) {
+		width = currentScreenConfig.screenWidth - 1;
+	}
+	else {
+		width = currentScreenConfig.screenWidth;
+	}
 
 	HomeCursor();
-	for(i = 0; i < currentScreenConfig.screenWidth; i++) {
+	for(i = 0; i < width; i++) {
 		chput('-');
 	}
 }
@@ -1636,10 +1646,12 @@ void chput(char ch) __naked
 {
     __asm
     push    ix
-    ld      ix,#4
+    push iy
+    ld      ix,#6
     add     ix,sp
     ld  a,(ix)
     call CHPUT
+    pop iy
     pop ix
     ret
     __endasm;

--- a/source/tools/C/printf.c
+++ b/source/tools/C/printf.c
@@ -74,10 +74,19 @@ static void do_char(const char* buf, char c) __naked
   jp z,5
 #else
   ld a,e
-  jp z,CHPUT
+  jr z,DO_CHPUT
 #endif
 
   ld (hl),e
+  ret
+
+  ;CHPUT shouldnt modify IX and IY but on some buggy MSX models it does 
+DO_CHPUT:
+  push ix
+  push iy
+  call CHPUT
+  pop iy
+  pop ix
   ret
 
   __endasm;

--- a/source/tools/C/system.h
+++ b/source/tools/C/system.h
@@ -43,5 +43,6 @@
 #define DAC 0xF7F6
 #define SCRMOD 0xFCAF
 #define EXPTBL 0xFCC1
+#define H_CHPH 0xFDA4
 
 #endif   //__SYSTEM_H


### PR DESCRIPTION
The problem (visible at least in the Daewoo CPC-400) is that the CHPUT routine is supposed to not modify the IX and IY registers, but in this computer it does since it does an inter-slot call to an internal slot (presumably to handle korean characters); this causes the PRINTF routine used by FDISK to crash.

Additionally, a small hack is added to print one less "-" character in the upper and lower rulers when that inter-slot call is performed, otherwise the FDISK screen isn't printed properly (it introduces an additional line break for some reason).

Closes https://github.com/Konamiman/Nextor/issues/100