### PR TITLE
Adjust crt0 for the C tools and FDISK for SDCC 4.2

### DIFF
--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -6,6 +6,7 @@
 ;
 	INCLUDE	../condasm.inc
 	INCLUDE ../const.inc
+	INCLUDE ../macros.inc
 ;
 ;===== end add DOS2.50
 ;

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -5855,14 +5855,6 @@ GET_DVB_NEXT:
 	scf
 	ret
 
-GET_DISKID_HL:
-	ld	hl,DISKID
-	ld	a,(hl)
-	inc	a
-	ret	nz
-	ld	hl,PROCNM+8
-	ret
-
 ;-----------------------------------------------------------------------------
 ;
 	PROC	DRVS2

--- a/source/kernel/bank5/fdisk_crt0.s
+++ b/source/kernel/bank5/fdisk_crt0.s
@@ -14,8 +14,9 @@ init:   ;call    gsinit
 
 	;--- Prepare parameters for main
 
-		push	hl
-        push    bc
+		ex de,hl
+		push bc
+		pop hl
 
         ;--- Step 3: Call the "main" function
 
@@ -28,8 +29,6 @@ init:   ;call    gsinit
 
 	;--- Terminate program
 
-	pop	af
-	pop af
 	ret
 
         ;--- Program code and data (global vars) start here

--- a/source/tools/C/crt0_msxdos_advanced.s
+++ b/source/tools/C/crt0_msxdos_advanced.s
@@ -114,9 +114,8 @@ parloopend:
         ;* Command line processing done. Here, C=number of parameters.
 
 cont:   ld      hl,#0x100
-        ld      b,#0
-        push    bc      ;Pass info as parameters to "main"
-        push    hl
+        ld      d,#0
+        ld      e,c      ;Pass info as parameters to "main"
 
         ;--- Step 3: Call the "main" function
 	push de


### PR DESCRIPTION
https://github.com/Konamiman/Nextor/pull/115 converted the C sources to the new calling convention introduced in SDCC 4.2 (passing arguments to functions in registers instead of in the stack), but that wasn't done for the `crt0` files used to compile the tools and FDISK. This pull request fixes that.

Also add a missing "include" statement in `init.mac`.