### PR TITLE
Fix a bug in MAPDRV and a bug in the MFRSD kernel regarding DEV_STATUS routine

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -3137,7 +3137,7 @@ MAP_SPECIFIC:
 
 MAP_DRV_UNK:
 	;Unknown change status: assume unchanged media.
-	;If it has changed, the boot checksum checksum
+	;If it has changed, the boot checksum
 	;mechanism will do the work of unassigning
 	;all other drives mapped to this device
 	;if necessary.
@@ -3147,6 +3147,7 @@ MAP_DRV_UNK:
 MAP_DRV_CH:
 	push	hl
 	push	iy
+	push	bc
 	ld	e,(hl)
 	inc	hl
 	ld	d,(hl)
@@ -3156,6 +3157,7 @@ MAP_DRV_CH:
 	ld	d,(iy+2)
 	ld	e,(iy+3)
 	call	UNMAPALL
+	pop bc
 	pop	iy
 	pop	hl
 

--- a/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
+++ b/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
@@ -666,7 +666,7 @@ DEV_RW:
 
 	;ld	hl,(#f9f0)
 	;inc	hl
-	;ld	(#f9f0),hl	; Cuenta lecturas
+	;ld	(#f9f0),hl	; Count reads
 		
 	call	SD_OFF
 	ei
@@ -677,6 +677,9 @@ DEV_RW:
 	ret
 	
 .ok:	
+	;A successful device access must reset the "device changed" flag
+	res	BIT_SD_CHG,(ix+STATUS)
+
 	xor	a		; Ok
 	ret
 


### PR DESCRIPTION
- The `MAPDRV` function call code was corrupting the register holding the drive number while unmapping all the drives assigned to the device in the case where the driver reports that the device has changed. Thus the mapping information ended up written to an incorrect memory area.

- The MegaFlashROM SCC+ SD driver was reporting "device changed" even after the device had been accessed with `DEV_RW`. A device is no longer considered as "changed" after it has been accessed.

Scenario to reproduce the issue:

- MFRSD with two cards, the second one has at least 2 partitions.
- On boot, A: is card 1 partition 1, B: is card 2 partition 1.
- Right after boot map any drive to card 2 partition 2: `MAPDDRV d: 2 3 1-3`
- Now switch to drive D:, computer crashes.