### PR TITLE
Make the DOSVER function call return 6Fh in C in DOS 1 mode

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -4169,7 +4169,7 @@ IDRVR_RET:
 
 DOSV1_2:
 	xor	a
-	ld	b,a
+	ld	bc,_DOSVER##  ;Make B=0 and preserve C, some programs actually check it
 	ret
 
 


### PR DESCRIPTION
MSX-DOS doesn't modify the main registers when an unknown function call is invoked, and the [Dutch Moonsound Veterans](https://www.msx.org/downloads/dutch-moonsound-veterans) music disk uses this fact to detect the MSX-DOS version in use, like this:

```
ld c,6Fh  ;_DOSVER function (introduced in MSX-DOS 2)
call F37Dh
ld a,c
cp 6Fh
ret z
;DOS 2 assumed from this point
```

However this MSX-DOS version detection method is technically incorrect. The [MSX-DOS 2 function codes specification](https://map.grauw.nl/resources/dos2_functioncalls.php) says the following regarding the `_DOSVER` function (emphasis mine):

> For compatibility with MSX-DOS 1.0, the following procedure should always be followed in using this function. Firstly if there is any error (A<>0) then it is  not MSX-DOS  at all. Next look at register B. If this is less than 2 then the system is earlier than 2.00 _**and registers C and DE are undefined**_.

Nextor does corrupt the C register when `_DOSVER` is invoked in MSX-DOS 1 mode (unless the magic numbers are supplied, see [the relevant documentation](https://github.com/Konamiman/Nextor/blob/v2.1/docs/Nextor%202.1%20Programmers%20Reference.md#28-_dosver-6fh)) and this is what causes the music disk to fail. So strictly speaking [the reported issue](https://github.com/Konamiman/Nextor/issues/120) is not a bug in Nextor but an incorrect usage of the function.

However, the fix is trivial and makes Nextor work more consistently with how "pure" MSX-DOS 1 does, thus this pull request implements it: now when `_DOSVER` is invoked in MSX-DOS 1 mode without the magic numbers supplied, it will preserve the contents of register C.

Closes #120.