### PR TITLE
Update MegaFlashROM SCC+ SD Boot Behavior (Duplicate Do not Merge)

### DIFF
--- a/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
+++ b/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
@@ -13,7 +13,7 @@ DRIVER_SUBVERSION	equ	3
 
 ;---------------------------------------------------------------------------
 ; MACROS
-;---------------------------------------------------------------------------				
+;---------------------------------------------------------------------------
 
 ADD_HL_A macro
 		add	a, l	; 4
@@ -68,10 +68,21 @@ CODE_ADD:	equ	0F2EDh
 
 ; BIOS
 ENASLT:		equ	#24
+INITXT		equ	#6C
 CHGET		equ	#9f
 CHPUT		equ	#A2	;Character output
 RSLREG:		equ	#138
-EXPTBL:		equ	#FCC1		
+EXTROM		equ	#15F
+
+SDFSCR		equ	#185
+REDCLK		equ	#1F5
+
+MSXVER		equ	#2D
+LINL40		equ	#F3AE	; Width
+LINLEN		equ	#F3B0
+BDRCLR		equ	#F3EB
+SCRMOD		equ	#FCAF
+EXPTBL:		equ	#FCC1
 SLTWRK:		equ	#FD09
 
 ; SD
@@ -357,11 +368,15 @@ DRV_TIMI:
 ;-----------------------------------------------------------------------------
 DRV_INIT:
 		or	a
-		jr	nz,.secondExe	; Second execution
+		jr	nz,.scrnset
 	
 		ld	hl,WORK_AREA_SIZE
 		;ld	a,NUM_DRIVES
 		ret		;Note that Cy is 0 (no interrupt hooking needed)
+
+.scrnset:
+		call	MYSETSCR
+		jr	nz,.secondExe	; Second execution
 
 .secondExe:
 		ld	de,TXT_INFO
@@ -395,8 +410,8 @@ DRV_INIT:
 		sub	b
 		ld	c,a
 		push	bc
-		ld	(#5800),a		; Select SD slot
-		call	InitSD			; Init SD card
+		ld	(#5800),a	; Select SD slot
+		call	InitSD		; Init SD card
 		call	SD_OFF
 		pop	bc			; C = SD slot
 		ei
@@ -415,7 +430,7 @@ DRV_INIT:
 
 		ld	b,e		; Card type
 		ld	de,TXT_INIT
-		call	PRINT		; Card init text
+		call	PRINT	; Card init text
 	
 		ld	a,c			; SD slot
 		add	a,'1'
@@ -430,7 +445,7 @@ DRV_INIT:
 		ld	e,(hl)
 		inc	hl
 		ld	d,(hl)
-		call	PRINT		; Shows card type
+		call	PRINT	; Shows card type
 .notCard:
 		pop	bc
 		djnz	.loop
@@ -1322,7 +1337,7 @@ InitSD:
 	ret	c			; Timeout (card removed or damaged?)
 	ret	nz			; Command error
 
-	;call	GETWRK			; Ya deber�a tener en IX el workarea
+	;call	GETWRK			; Ya deber?a tener en IX el workarea
 	
 	res	BIT_SDHC,(ix+STATUS)	; Set SDSC as default
 	
@@ -1461,7 +1476,7 @@ MMC_FOUND:
 
 ;-----------------------------------------------------------------------------
 ; Inicializa la SD y pone el modo SPI.
-; Si no se hace as� falla en el FS-A1.
+; Si no se hace as? falla en el FS-A1.
 ; Aparentemente, si se escribe el CRC (#95) desde un registro falla.
 ;-----------------------------------------------------------------------------
 SD_INIT:
@@ -1603,7 +1618,7 @@ SD_CMD:
 	ld	b,0
 SD_CMD2:
 	ld	a,(de)
-	cp	#ff		; Aqu� se podr�a mirar solo el bit 7? 0=ready
+	cp	#ff		; Aqu? se podr?a mirar solo el bit 7? 0=ready
 	ccf
 	ret	nc
 
@@ -2149,34 +2164,82 @@ PRINT:
 		include	"romdisk.asm"
 
 ;-----------------------------------------------------------------------------
+;
+; Restore screen parameters on MSX>=2 if they're not set yet
+; Input   : none
+; Output  : none
+; Modifies: all
+MYSETSCR:
+	ld	a,(MSXVER)
+	or	a
+	jr	nz,.notMSX1
+
+.MSX1:
+	ld	a,(SCRMOD)
+	or	a
+	ret
+	jp	INITXT
+
+.notMSX1:
+	ld	c,23h
+	ld 	ix,REDCLK
+	call	EXTROM
+	and	1
+	ld	b,a
+	ld	a,(SCRMOD)
+	cp	b
+	jr	nz,.restore
+	inc	c
+	ld 	ix,REDCLK
+	call	EXTROM
+	ld	b,a
+	inc	c
+	ld 	ix,REDCLK
+	call	EXTROM
+	add	a,a
+	add	a,a
+	add	a,a
+	add	a,a
+	or	b
+	ld	b,a
+	ld	a,(LINLEN)
+	cp	b
+	ret	z
+.restore:
+	xor	a
+	ld	ix,SDFSCR
+	jp	EXTROM
+
+;-----------------------------------------------------------------------------
 ; Strings
 ;-----------------------------------------------------------------------------
 
 VERSION_STRING macro v_main, v_sub
-db	"Version &v_main&.&v_sub&",13,10
+db	"version &v_main&.&v_sub&",13,10
 endm
 
 TXT_INFO:
-		db	"MegaFlashROM SCC+ SD driver",13,10
+		db	"MegaFlashROM SCC+ SD driver "
 		VERSION_STRING %DRIVER_VERSION,%DRIVER_SUBVERSION
-		db	"(c) Manuel Pazos 2013",13,10
+		db	"(c) 2013 Manuel Pazos",13,10
 TXT_EMPTY:		
 		db	13,10,0
 
 TXT_INIT:
-		db	"SD card slot ",0
+		db	"SD Card slot ",0
 
 TXT_ROMDSKOK:
-		db	"ROM disk found.",13,10,0
+		db	"ROM Disk found.",13,10
+		db	13,10,0
 
 TXT_MMC:
-		db	"MMC",13,10,0
+		db	" MMC",13,10,0
 TXT_SD1x:
-		db	"SDSC 1.x",13,10,0
+		db	" SDSC 1.x",13,10,0
 TXT_SD2x:
-		db	"SDSC 2.x",13,10,0
+		db	" SDSC 2.x",13,10,0
 TXT_SDHC:
-		db	"SDHC",13,10,0
+		db	" SDHC",13,10,0
 	
 IDX_TYPE:
 		dw	TXT_MMC


### PR DESCRIPTION
Repost of the earlier closed commit because I couldn't rebase as suggested by @grauw. All changes made should appear in this single commit.

This PR gives the MegaFlashROM the same boot behavior as the Sunrise IDE driver 0.1.7, that is restore the MSX saved screen parameters at boot if they've been saved by the RTC on MSX2 and higher computers.

Given that I'm currently traveling, I was only able to test and confirm it working with OpenMSX. But thankfully this shouldn't bring up any other unrelated behaviors since it's a cosmetic change at most.

This PR should thankfully close [#126](https://github.com/Konamiman/Nextor/issues/126) 