### PR TITLE
Update MegaFlashROM SCC+ SD Boot Behavior

### DIFF
--- a/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
+++ b/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
@@ -68,10 +68,21 @@ CODE_ADD:	equ	0F2EDh
 
 ; BIOS
 ENASLT:		equ	#24
+INITXT		equ	#6C
 CHGET		equ	#9f
 CHPUT		equ	#A2	;Character output
 RSLREG:		equ	#138
-EXPTBL:		equ	#FCC1		
+EXTROM		equ	#15F
+
+SDFSCR		equ	#185
+REDCLK		equ	#1F5
+
+MSXVER		equ	#2D
+LINL40		equ	#F3AE
+LINLEN		equ	#F3B0
+BDRCLR		equ	#F3EB
+SCRMOD		equ	#FCAF
+EXPTBL:		equ	#FCC1
 SLTWRK:		equ	#FD09
 
 ; SD
@@ -357,11 +368,15 @@ DRV_TIMI:
 ;-----------------------------------------------------------------------------
 DRV_INIT:
 		or	a
-		jr	nz,.secondExe	; Second execution
+		jr	nz,.scrnSet
 	
 		ld	hl,WORK_AREA_SIZE
 		;ld	a,NUM_DRIVES
 		ret		;Note that Cy is 0 (no interrupt hooking needed)
+
+.scrnSet:
+		call	USRSCRSET
+		jr	nz,.secondExe	; Second execution
 
 .secondExe:
 		ld	de,TXT_INFO
@@ -1322,7 +1337,7 @@ InitSD:
 	ret	c			; Timeout (card removed or damaged?)
 	ret	nz			; Command error
 
-	;call	GETWRK			; Ya deber�a tener en IX el workarea
+	;call	GETWRK			; Ya debería tener en IX el workarea
 	
 	res	BIT_SDHC,(ix+STATUS)	; Set SDSC as default
 	
@@ -1461,7 +1476,7 @@ MMC_FOUND:
 
 ;-----------------------------------------------------------------------------
 ; Inicializa la SD y pone el modo SPI.
-; Si no se hace as� falla en el FS-A1.
+; Si no se hace así falla en el FS-A1.
 ; Aparentemente, si se escribe el CRC (#95) desde un registro falla.
 ;-----------------------------------------------------------------------------
 SD_INIT:
@@ -1603,7 +1618,7 @@ SD_CMD:
 	ld	b,0
 SD_CMD2:
 	ld	a,(de)
-	cp	#ff		; Aqu� se podr�a mirar solo el bit 7? 0=ready
+	cp	#ff		; Aquí se podría mirar solo el bit 7? 0=ready
 	ccf
 	ret	nc
 
@@ -2149,6 +2164,50 @@ PRINT:
 		include	"romdisk.asm"
 
 ;-----------------------------------------------------------------------------
+; Restore screen parameters on MSX>=2 if they're not set yet
+;-----------------------------------------------------------------------------
+USRSCRSET:
+	ld	a,(MSXVER)
+	or	a
+	jr	nz,.notMSX1
+
+.MSX1:
+	ld	a,(SCRMOD)
+	or	a
+	ret
+	jp	INITXT
+
+.notMSX1:
+	ld	c,23h
+	ld 	ix,REDCLK
+	call	EXTROM
+	and	1
+	ld	b,a
+	ld	a,(SCRMOD)
+	cp	b
+	jr	nz,.restore
+	inc	c
+	ld 	ix,REDCLK
+	call	EXTROM
+	ld	b,a
+	inc	c
+	ld 	ix,REDCLK
+	call	EXTROM
+	add	a,a
+	add	a,a
+	add	a,a
+	add	a,a
+	or	b
+	ld	b,a
+	ld	a,(LINLEN)
+	cp	b
+	ret	z
+.restore:
+	xor	a
+	ld	ix,SDFSCR
+	jp	EXTROM
+
+;-----------------------------------------------------------------------------
 ; Strings
 ;-----------------------------------------------------------------------------
 
@@ -2159,24 +2218,25 @@ endm
 TXT_INFO:
 		db	"MegaFlashROM SCC+ SD driver",13,10
 		VERSION_STRING %DRIVER_VERSION,%DRIVER_SUBVERSION
-		db	"(c) Manuel Pazos 2013",13,10
+		db	"(c) 2013 Manuel Pazos",13,10
 TXT_EMPTY:		
 		db	13,10,0
 
 TXT_INIT:
-		db	"SD card slot ",0
+		db	"SD Card slot ",0
 
 TXT_ROMDSKOK:
-		db	"ROM disk found.",13,10,0
+		db	"ROM Disk found.",13,10
+		db	13,10,0
 
 TXT_MMC:
-		db	"MMC",13,10,0
+		db	" MMC",13,10,0
 TXT_SD1x:
-		db	"SDSC 1.x",13,10,0
+		db	" SDSC 1.x",13,10,0
 TXT_SD2x:
-		db	"SDSC 2.x",13,10,0
+		db	" SDSC 2.x",13,10,0
 TXT_SDHC:
-		db	"SDHC",13,10,0
+		db	" SDHC",13,10,0
 	
 IDX_TYPE:
 		dw	TXT_MMC


### PR DESCRIPTION
This PR gives the MegaFlashROM SCC+ SD the same boot behavior as the Sunrise IDE driver v0.1.7, that is to restore the MSX saved screen parameters at boot if they've been saved by the RTC on MSX2 or higher computers.

Given that I'm currently traveling, I was only able to test and confirm it working with OpenMSX on a FS-A1WSX and FS-A1GT using both 1 and 2 slots flavors of the ROM.

Thankfully the changes made shouldn't bring up any unrelated behaviors since they're only cosmetic at most.

Closes [#126](https://github.com/Konamiman/Nextor/issues/126).