### PR TITLE
Fix DSKIO driver error check in DOS 1, page 1 transfers

### DIFF
--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -259,8 +259,6 @@ CAPSOFF:
 	ret
 
 
-
-
     ALIGN 781Fh
 ;-----------------------------------------------------------------------------
 ;
@@ -277,6 +275,18 @@ null_message:
 	db	"2 - Double side",13,10
 	db	0
 
+
+; Moved here due to space constraints
+
+DO_DIRCALL:
+	pop	ix
+	push	bc
+	ld	bc,DV_D0##-DIRCALL-3
+	add	ix,bc
+	pop	bc
+	jp	DO_CALBNK
+
+
 ;-----------------------------------------------------------------------------
 ;
 ; Entries for direct calls.
@@ -292,13 +302,27 @@ DIRCALL:
 	call	DO_DIRCALL
 	call	DO_DIRCALL
 
-DO_DIRCALL:
-	pop	ix
-	push	bc
-	ld	bc,DV_D0##-DIRCALL-3
-	add	ix,bc
-	pop	bc
-	jp	DO_CALBNK
+
+; Process the output of DSKIO so that Cy is set
+; if an error has been returned.
+
+DIO_SET_ERR_FLAG::
+	push af
+	ld a,(KSLOT##)
+	or a
+	jr z,DIO_SET_ERR_FLAG_END
+
+	;Device-based: set Cy if error code is not 0
+	pop af
+	or a
+	ret z
+	scf
+	ret
+
+	;Drive-based driver: result will already have Cy set on error
+DIO_SET_ERR_FLAG_END:
+	pop af
+	ret
 
 
 ;-----------------------------------------------------------------------------
@@ -478,14 +502,8 @@ DIO_RD_LOOP:
 	push	de		;with a simple call to the driver
 	push	hl
 	
-	ld	hl,($SECBUF##)
-	ld	b,1
 	or	a
-	
-	ld	ix,DV_DSKIO##	;Or DEV_RW (they are at the same address)
-	ex	af,af'
-	ld	a,DV_BANK##
-	call	CALBNK##
+	call DIO_DO_CALDRV
 	jr	nc,DIO_RD_OK
 
 	pop	hl	;On disk error, just return
@@ -532,14 +550,8 @@ DIO_WR_LOOP:
 	push	bc
 	push	de
 
-	ld	hl,($SECBUF##)
-	ld	b,1
 	scf
-	
-	ld	ix,DV_DSKIO##
-	ex	af,af'
-	ld	a,DV_BANK##
-	call	CALBNK##
+	call DIO_DO_CALDRV
 	jr	nc,DIO_WR_OK
 
 	pop	de	;On disk error, just return
@@ -560,6 +572,17 @@ DIO_WR_OK:
 
 	xor	a
 	ret	
+
+
+DIO_DO_CALDRV:
+	ld	hl,($SECBUF##)
+	ld	b,1
+	
+	ld	ix,DV_DSKIO##
+	ex	af,af'
+	ld	a,DV_BANK##
+	call	CALBNK##
+	jp DIO_SET_ERR_FLAG
 
 
 ; Jump here when the transfer can be done in a single step
@@ -975,10 +998,6 @@ POP_CONV_ERR:
 CONV_ERR:
 	or	a
 	ret	z
-	;jr	c,CONVE2
-	;xor	a
-	;ret
-CONVE2:
 
 	push	bc
 	ld	b,0


### PR DESCRIPTION
This pull request fixes code in `drv.mac` that was assuming that the driver routine `DEV_RW`/`DSKIO` sets Cy=1 to signal an error, however this is true only for drive-based drivers, but not for device-based drivers. This incorrect behavior was happening only in DOS 1 mode and only for transfers to page 1.

Inspired by https://github.com/Konamiman/Nextor/pull/111.