### PR TITLE
Fixes in crt0_msxdos_advanced and printf.c

### DIFF
--- a/source/tools/C/crt0_msxdos_advanced.s
+++ b/source/tools/C/crt0_msxdos_advanced.s
@@ -129,7 +129,7 @@ cont:   ld      hl,#0x100
         ;    Termination code for DOS 2 was returned on L.
                 
         ld      c,#0x62   ;DOS 2 function for program termination (_TERM)
-        ld      b,l
+        ld      b,a
         call    5      ;On DOS 2 this terminates; on DOS 1 this returns...
         ld      c,#0x0
         jp      5      ;...and then this one terminates

--- a/source/tools/C/printf.c
+++ b/source/tools/C/printf.c
@@ -11,7 +11,7 @@
    Supported format specifiers:
 
    %d or %i: signed int
-   %ud or %ui: unsigned int
+   %u: unsigned int
    %x: hexadecimal int
    %c: character
    %s: string
@@ -20,7 +20,7 @@
    Also if SUPPORT_LONG is defined:
 
    %l: signed long
-   %ul: unsigned long
+   %lu: unsigned long
    %lx: hexadecimal long
 */
 
@@ -160,7 +160,12 @@ static int format_string(const char* buf, const char *fmt, va_list ap)
     else if(theChar == 'x') {
       base = 16;
     }
-    else if(theChar != 'd' && theChar != 'i') {
+#ifdef SUPPORT_LONG
+    else if(isLong) {
+      fmtPnt--;
+    } else
+#endif    
+    if(theChar != 'd' && theChar != 'i') {
       do_char_inc(theChar);
       continue;
     }


### PR DESCRIPTION
* Fix error code returned to the OS in crt0_msxdos_advanced.
  * It was being taken from register L, but in newer SDCCs it's passed in register A instead.

* Fixes in long integer handling in printf.c
  * Doc comment fixed: now it correctly says that the modifier for integers is "u" (not "ud" or "ui") and for unsigned long is "lu" (not "ul").
  * Fixed the "l" modifier, it was skipping the next character.
