### PR TITLE
Adds support for easy building Nextor with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ NEXTORK.SYS
 nextor_base.dat
 *.LST
 
+dist/

--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ There are five makefiles that will take care of building the different component
 
 You may want to take a look at [this now closed pull request from Dean Netherton](https://github.com/Konamiman/Nextor/pull/79) that contains a different attempt at writing makefiles for bulding Nextor. It even has some nice extra features like building FDD and HDD images with Nextor, and building the `mknexrom` tool itself.
 
+## How to build Nextor on all platforms with Docker
+
+Using this method for building Nextor is easier. Everything you need for compiling Nextor already installed in the Docker image. If you have [Docker](https://www.docker.com) installed you can build Nextor on Linux, macOS and Windows, on Arm64 and Intel x86_64 by running the following command:
+
+```sh
+./build_nextor.sh
+```
+
+After compilation, the `ROM` files will be available in the `dist` directory.
+
+_Note that the `build_builder.sh` and the content in the `docker` directory are used to create the Docker builder image. You don't need to run them to build Nextor._

--- a/build_builder.sh
+++ b/build_builder.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Builds the bulder image from the docker/Dockerfile.builder file for Intel and
+# ARM architectures. The image is then pushed to Docker Hub.
+# Note that you don't need to run this script for building Nextor ROMs. Only use
+# this script if you want to create the builder image yourself.
+#
+# usage: ./build_builder.sh
+
+set -e
+
+# Change the USER and REPO to your Docker Hub username and repository name
+USER=gilbertfrancois
+REPO=nextor-builder
+VERSION=v1.0.0
+IMAGE=${REPO}
+BUILDER_CONTAINER_NAME=${REPO}-docker-builder
+PLATFORM="linux/amd64,linux/arm64"
+
+if [[ $(docker container ls -a | grep ${BUILDER_CONTAINER_NAME} | wc -l) -eq 1 ]]; then
+	echo "Builder container exists, skipping creation."
+else
+	docker buildx create --name ${BUILDER_CONTAINER_NAME}
+	docker buildx use ${BUILDER_CONTAINER_NAME}
+	docker buildx inspect --bootstrap
+fi
+# Create a new builder instance, if not already created
+docker buildx build --platform=linux/amd64,linux/arm64 \
+	--tag ${USER}/${REPO}:${VERSION} \
+	--tag ${USER}/${REPO}:latest \
+	-f docker/Dockerfile.builder \
+	--push \
+	.

--- a/build_nextor.sh
+++ b/build_nextor.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Builds the Nextor ROMs using the Docker image gilbertfrancois/nextor-builder:latest
+# The ROM artefacts are copied to the dist directory after building.
+#
+# usage: ./build_nextor.sh
+
+set -e
+
+rm -rf dist
+mkdir -p dist
+
+cat <<EOF | docker run --rm --interactive \
+	-v $(pwd)/dist:/dist \
+	-v $(pwd)/source:/workdir/source \
+	gilbertfrancois/nextor-builder:latest \
+	/bin/bash
+	make -C /workdir/source clean all
+    find /workdir/source -name *.ROM | xargs cp -t /dist 
+EOF

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,0 +1,27 @@
+FROM ubuntu:24.04
+
+ENV N80_VERSION=1.2
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    binutils \
+    build-essential \
+    bzip2 \
+    git \
+    sdcc \
+    libicu-dev \
+    make \
+    pkg-config \
+    python3-dev \
+    unzip \
+    wget 
+
+WORKDIR /downloads
+COPY ./docker/install_N80.sh /downloads
+RUN chmod 755 /downloads/install_N80.sh
+RUN /downloads/install_N80.sh
+
+WORKDIR /workdir
+COPY ./buildtools/sources/mknexrom.c /workdir
+RUN gcc -o /usr/bin/mknexrom /workdir/mknexrom.c
+RUN chmod +x /usr/bin/mknexrom

--- a/docker/install_N80.sh
+++ b/docker/install_N80.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Installs the N80, LK80 and LB80 tools from the Nestor80 project. The script
+# is intended to be run in a Docker container.
+
+set -e
+
+if [ $(uname -m) == 'x86_64' ]; then
+	wget -O /downloads/n80.zip https://github.com/Konamiman/Nestor80/releases/download/n80-v1.2/N80_${N80_VERSION}_SelfContained_linux-x64.zip
+	wget -O /downloads/lk80.zip https://github.com/Konamiman/Nestor80/releases/download/lk80-v1.0/LK80_1.0_SelfContained_linux-x64.zip
+	wget -O /downloads/lb80.zip https://github.com/Konamiman/Nestor80/releases/download/lb80-v1.0/LB80_1.0_SelfContained_linux-x64.zip
+elif [ $(uname -m) == 'aarch64' ]; then
+	wget -O /downloads/n80.zip https://github.com/Konamiman/Nestor80/releases/download/n80-v1.2/N80_${N80_VERSION}_SelfContained_linux-arm64.zip
+	wget -O /downloads/lk80.zip https://github.com/Konamiman/Nestor80/releases/download/lk80-v1.0/LK80_1.0_SelfContained_linux-arm64.zip
+	wget -O /downloads/lb80.zip https://github.com/Konamiman/Nestor80/releases/download/lb80-v1.0/LB80_1.0_SelfContained_linux-arm64.zip
+fi
+
+unzip /downloads/n80.zip
+unzip /downloads/lk80.zip
+unzip /downloads/lb80.zip
+chmod +x N80
+chmod +x LK80
+chmod +x LB80
+mv N80 /usr/bin
+mv LK80 /usr/bin
+mv LB80 /usr/bin


### PR DESCRIPTION
Adds support for easy building Nextor with Docker.

Dear Konamiman,

I wanted to build the latest Nextor on my machine. However, I'm running on a mac with arm processor and saw that Linux is the preferred OS for building this project. That's why I created this docker image (for arm64 and x86_64). Maybe it is useful for other users too, running e.g. Windows, macOS or even Linux, without having the required build tools installed on their system. That is why I propose this pull request.

The only step needed to build Nextor is running the script `build_nextor.sh`. The ROMs will be available in the `dist` directory after compilation.

I hope you will consider merging it in your great project.

PS: It was nice to meet you in Amsterdam in december :)