### PR TITLE
Modify ZAP_ALL to skip drives assigned to device-based drivers

### DIFF
--- a/source/kernel/bank2/val.mac
+++ b/source/kernel/bank2/val.mac
@@ -3060,6 +3060,13 @@ zap_all_loop:	ld	a,b			;Get logical unit number
 		or	e
 		jr	z,no_zap_unit		;Skip if zero (no unit)
 ;
+		push hl				;Only zap if the unit is not controlled
+		ld de,UD_FLAGS      ;by a device-based driver
+		add hl,de
+		bit UF_DBD,(hl)
+		pop hl
+		jr nz,no_zap_unit
+
 		ld	hl,UD_TIME##
 		add	hl,de			;HL -> UD_TIME byte
 		ld	a,(hl)			;If UD_TIME is non-zero then


### PR DESCRIPTION
The `ZAP_ALL` routine, called when the `_FLUSH` function call is executed with the "invalidate" flag, deletes all the unit descriptors, the idea being that they will be regenerated on the next drive access.

While this works fine for MSX-DOS drives and Nextor drives assigned to drive-based drivers, for device-based drives this means that the drive will undergo an autoassign procedure, which often will result in the drive either getting a different mapping or no mapping at all; this is confusing and probably not what the user wants.

This pull request modifies `ZAP_ALL` so that it skips the deletion of unit descriptors assigned to device-based drivers.

Closes #146

### How to test

This can be tested by mapping ani drive to a non-default mapping, for example `mapdrv h: 2 1 0` to map partition 2 of device 1 in the primary mapper to drive H: (assuming that the drive is unmapped by default). Then run the following code:

```
ld b,0FFh ;All drives
ld c,5Fh ;_FLUSH
ld d,0FFh ;Invalidate
call 5
```

Without this fix this results in drive H: getting unmapped, with this fix the drive mapping is unaffected.