### PR TITLE
Fix crash on sector buffer invalidation after writing to device

### DIFF
--- a/source/kernel/bank2/rw.mac
+++ b/source/kernel/bank2/rw.mac
@@ -388,6 +388,8 @@ correct_loop:	push	bc
 		add	hl,bc
 		ld	a,(hl)			;A := sector number (bit16-22)
 						; from this buffer
+		sbc hl,bc
+
 ;===== end add FAT16
 		ex	de,hl
 		ld	bc,(RW_PSEC##)		;Compare with sector number


### PR DESCRIPTION
This pull request fixes a bug that was introduced when FAT16 support was introduced in the `CORRECT_BUF` routine. When a buffer had to be invalidated after a write, the pointer to the buffer in the buffer chain had been corrupted, and the process eventually caused a crash.

This is difficult to test but some people has reported it being reproduced while using the AKID text editor. See also #142.

Closes #142