### PR TITLE
Fix _GETCLUS copying 64 bytes of data instead of 16

### DIFF
--- a/source/command/msxdos/sys.mac
+++ b/source/command/msxdos/sys.mac
@@ -1392,19 +1392,28 @@ KBDOS:
 ;	LD	E,RELEASE##+(RELEASE##/256)*16
 ;	RET
 
+@GETCLUS:
+	ld b,16
+	jr _RUN_AND_COPY
+
 @GDRVR:
 @GDLI:
-@GETCLUS:
+	ld b,64
+
+_RUN_AND_COPY:
 	push	hl
+	push bc
 	LD	HL,BUFF3
 	call	GO_BDOS##
+	pop bc
 	pop	hl
 	or	a
 	ret	nz
 	push	hl
 	ex	de,hl
+	ld c,b
+	ld b,0
 	ld	hl,BUFF3
-	ld	bc,64
 	ldir
 	pop	hl
 	ret


### PR DESCRIPTION
When `_GETCLUS` was invoked via `call 5`, the supplied user buffer was filled by 64 bytes of data, instead of 16 as the description of the function call states.

Closes #145