### PR TITLE
Fix "map to device sector 0" option in CALL MAPDRV

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -4488,7 +4488,7 @@ MAPDRV_NOGETCUR:
 	ld	hl,0
 	ld	(MAPDRV_SEC),hl
 	ld	(MAPDRV_SEC+2),hl
-	jr	MAPDRV_GOTPAR
+	jr	MAPDRV_GOT_PAR_SEC
 MAPDRV_NOP0:
 
 	;* If partition number is 2 to 4, convert it to primary or logical
@@ -4549,6 +4549,7 @@ MAPDRV_GOTPAR:
 
 	ld	(MAPDRV_SEC),de
 	ld	(MAPDRV_SEC+2),hl
+MAPDRV_GOT_PAR_SEC:
 
 	;* Perform the mapping
 


### PR DESCRIPTION
The `CALL MAPDRV` BASIC command has an option to map a drive directly to sector zero of a device (for cases where the device doesn't have partitions and the FAT filesystem starts directly at sector zero), by specifying zero as the partition number. However this option wasn't actually working, it would always throw an "Invalid partition" error. This pull request fixes that.

Note that this bug was in the `CALL MAPDRV` BASIC command only, the command line tool `MAPDRV.COM` already works as expected.