### PR TITLE
Activate support for long integers in the printf routine

### DIFF
--- a/source/kernel/bank5/fdisk.c
+++ b/source/kernel/bank5/fdisk.c
@@ -1229,7 +1229,7 @@ void TestDeviceAccess()
 	InitializeScreenForTestDeviceAccess(message);
 
 	while(GetKey() == 0) {
-		sprintf(buffer, "%u", sectorNumber);
+		sprintf(buffer, "%lu", sectorNumber);
 		//_ultoa(sectorNumber, buffer, 10);
 		Locate(messageLen, MESSAGE_ROW);
 		print(buffer);

--- a/source/kernel/bank5/fdisk.c
+++ b/source/kernel/bank5/fdisk.c
@@ -1230,7 +1230,6 @@ void TestDeviceAccess()
 
 	while(GetKey() == 0) {
 		sprintf(buffer, "%lu", sectorNumber);
-		//_ultoa(sectorNumber, buffer, 10);
 		Locate(messageLen, MESSAGE_ROW);
 		print(buffer);
 		print(" ...\x1BK");
@@ -1245,7 +1244,7 @@ void TestDeviceAccess()
 
 		if((error = regs.Bytes.A) != 0) {
 			strcpy(buffer, errorMessageHeader);
-			sprintf(buffer + strlen(errorMessageHeader), "%u", sectorNumber);
+			sprintf(buffer + strlen(errorMessageHeader), "%lu", sectorNumber);
 			strcpy(buffer + strlen(buffer), ":");
 			PrintDosErrorMessage(error, buffer);
 			PrintStateMessage("Continue reading sectors? (y/n) ");

--- a/source/tools/C/printf.c
+++ b/source/tools/C/printf.c
@@ -160,12 +160,7 @@ static int format_string(const char* buf, const char *fmt, va_list ap)
     else if(theChar == 'x') {
       base = 16;
     }
-#ifdef SUPPORT_LONG
-    else if(isLong) {
-      fmtPnt--;
-    } else
-#endif    
-    if(theChar != 'd' && theChar != 'i') {
+    else if(theChar != 'd' && theChar != 'i') {
       do_char_inc(theChar);
       continue;
     }

--- a/source/tools/C/printf.c
+++ b/source/tools/C/printf.c
@@ -24,7 +24,7 @@
    %lx: hexadecimal long
 */
 
-//#define SUPPORT_LONG
+#define SUPPORT_LONG
 
 #include <stdarg.h>
 #include "system.h"


### PR DESCRIPTION
Support for printing long integers in `printf.c` was disabled, this caused the "Test device access" tool in FDISK to display "Now reading device sector u" instead of the actual sector number.

Additionally, printing long numbers wasn't properly implemented in `printf.c`. That's also fixed.