### PR TITLE
Fix key scanning for disk change on floppy emulation mode

### DIFF
--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -230,11 +230,11 @@ GETCURKEY:
     ;A = Current key index
     ;We do an initial rotation because we want to start at key 1.
 CHGLOOP:
-    sra c
-    rr e
-    rr d
+	srl h
     rr l
-    rr h
+    rr d
+    rr e
+    rr c
     bit 0,c
     ret nz
 


### PR DESCRIPTION
The mechanism to [change the current image file in disk emulation mode](https://github.com/Konamiman/Nextor/blob/v2.1/docs/Nextor%202.1%20User%20Manual.md#392-changing-the-image-file) was broken and actually only the first seven image files could be switched to, making it impossible to play games consisting of eight or more disks using disk emulation mode. This pull request fixes this.
