### PR TITLE
v2.1.4

### DIFF
--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -8,7 +8,7 @@
 # N80=/path/to/N80 make
 
 
-VERSION := 2.1.3
+VERSION := 2.1.4
 
 ifeq ($(strip $(N80)),)
 N80=N80

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -1656,21 +1656,13 @@ CHECK_FAT_BOOT:
 
 		ld	c,(iy+UPB_NUM_ROOT_DIR_ENTRIES##)
 		ld	b,(iy+UPB_NUM_ROOT_DIR_ENTRIES##+1)	;BC=Num of root dir entries
-		ld	a,c
-		and	11111b
-		ld	hl,0
-		jr	z,NO_ODD_ENTRIES
-		ld	hl,1
-NO_ODD_ENTRIES:
-		srl	b	;Divide by 32
-		rr	c
-		srl	b
-		rr	c
-		srl	b
-		rr	c
-		srl	b
-		rr	c	
-		add	hl,bc	;HL=Num of root dir sectors
+		ld	hl,15
+		add hl,bc
+		ld b,4
+CALC_SECDIR:
+		srl	h	;Divide by 16, round up
+		rr	l
+		djnz CALC_SECDIR	;HL=Num of root dir sectors
 
 		ld	c,(iy+UPB_RESERVED_SECTORS##)
 		ld	b,(iy+UPB_RESERVED_SECTORS##+1)
@@ -1947,11 +1939,13 @@ CALC_1SECDIR:
 	ld	(iy+17),h
 	ex	de,hl
 
-	;1er data sector =(Reserved sectors+Num FATs*Sectors per FAT)+
+	;1st data sector =(Reserved sectors+Num FATs*Sectors per FAT)+
 	;                 (32*Directory entries/512)
 
-	ld	l,(ix+17)	;Calculate directory entries/16
+	ld	l,(ix+17)	;Calculate directory entries/16, round up
 	ld	h,(ix+18)
+	ld	bc,15
+	add	hl,bc
 	ld	b,4
 CALC_1SECDAT:
 	srl	h
@@ -1965,7 +1959,7 @@ CALC_1SECDAT:
 	;Num clusters+1=((Total sectors-1st data sector)/Sectors per cluster)+1
 
 	push	hl
-	pop	bc	;DE=1st data sector
+	pop	bc	;BC=1st data sector
 	ld	l,(ix+19)
 	ld	h,(ix+20)
 	ld	de,0

--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -230,11 +230,11 @@ GETCURKEY:
     ;A = Current key index
     ;We do an initial rotation because we want to start at key 1.
 CHGLOOP:
-    sra c
-    rr e
-    rr d
+	srl h
     rr l
-    rr h
+    rr d
+    rr e
+    rr c
     bit 0,c
     ret nz
 

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -26,7 +26,7 @@
 	const	SEC_DOS_VERSION_LOW,1	;Minor version number, low nybble
 	const	MAIN_NEXTOR_VERSION,2
 	const	SEC_NEXTOR_VERSION_HIGH,1
-	const	SEC_NEXTOR_VERSION_LOW,3
+	const	SEC_NEXTOR_VERSION_LOW,4
 ;===== end mod DOS2.50
 ;
 ;


### PR DESCRIPTION
* [Fix key scanning for disk change on floppy emulation mode](https://github.com/Konamiman/Nextor/pull/161)
* [Fix the calculation of the root directory size](https://github.com/Konamiman/Nextor/pull/158)

And:

* [Update kernel version number to 2.1.4](https://github.com/Konamiman/Nextor/pull/162)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.1.4
  * Updated DOS 2.50 mod version identifier

* **Refactor**
  * Optimized FAT boot sector calculations for enhanced compatibility
  * Refined key-change processing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->