### PR TITLE
[Nextor 3] Rename "SunriseIDE.emulators.ROM" file to "SunriseIDE.blueMSX.ROM"

### DIFF
--- a/docs/Nextor 2.1 Getting Started Guide.md
+++ b/docs/Nextor 2.1 Getting Started Guide.md
@@ -41,7 +41,7 @@ This section explains the steps needed to setup blueMSX in order to follow this 
 
 a. Download the following files from [the lastest release of Nextor in GitHub](https://github.com/Konamiman/Nextor/releases/latest):
 
-* Nextor kernel with Sunrise IDE driver. Please choose the file with _.SunriseIDE.emulators.ROM_ extension (the _.SunriseIDE.ROM_ version works but only recgonizes the slave IDE device in emulators).
+* Nextor kernel with Sunrise IDE driver. Please choose the file with _.SunriseIDE.blueMSX.ROM_ extension (the _.SunriseIDE.ROM_ version works but only recognizes the slave IDE device in blueMSX), if you are using another emulator or a physical Sunrise IDE (or compatible) controller hardware you can use the file with _.SunriseIDE.ROM_ extension instead.
 
 * Nextor tools disk image (_tools.dsk.zip_).
 

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -126,11 +126,11 @@ drivers/SunriseIDE/sunride.masteronly.bin: \
 	$(call assemble_as,drivers/SunriseIDE/sunride.asm,$$/sunride.masteronly.bin,--build-type abs --output-file-extension bin --define-symbols MASTER_ONLY,BAD_POPS)
 
 
-### Sunrise IDE, ROM for emulators
+### Sunrise IDE, ROM for blueMSX
 
-ide-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.emulators.ROM
+ide-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.blueMSX.ROM
 
-drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.emulators.ROM: \
+drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.blueMSX.ROM: \
 	nextor_base.dat \
 	drivers/SunriseIDE/driver.bin \
 	drivers/SunriseIDE/chgbnk.bin \
@@ -146,11 +146,11 @@ drivers/SunriseIDE/driver.bin: \
 	$(call assemble,drivers/SunriseIDE/driver.mac,--build-type abs --output-file-extension bin)
 
 
-### Sunrise IDE, ROM for emulators, master device only
+### Sunrise IDE, ROM for blueMSX, master device only
 
-ide-masteronly-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.emulators.ROM
+ide-masteronly-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.blueMSX.ROM
 
-drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.emulators.ROM: \
+drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.blueMSX.ROM: \
 	nextor_base.dat \
 	drivers/SunriseIDE/drvmonly.bin \
 	drivers/SunriseIDE/chgbnk.bin \

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -64,7 +64,7 @@ endef
 ###  MAIN RULE  ###
 ###################
 
-all: base ide ide-masteronly ide-emu ide-masteronly-emu ascii8 ascii16 mfrsd flashjacks ocm
+all: base ide ide-masteronly ide-blue ide-masteronly-emu ascii8 ascii16 mfrsd flashjacks ocm
 
 TOOLS := $(N80) $(LK80) $(LB80) objcopy sdcc $(MKNEXROM) dd
 
@@ -128,7 +128,7 @@ drivers/SunriseIDE/sunride.masteronly.bin: \
 
 ### Sunrise IDE, ROM for blueMSX
 
-ide-emu: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.blueMSX.ROM
+ide-blue: drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.blueMSX.ROM
 
 drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.blueMSX.ROM: \
 	nextor_base.dat \


### PR DESCRIPTION
"Backport" of #129.

Additionally, rename the `ide-emu` target in the makefile to `ide-blue`.

Part of #164
