### PR TITLE
[Nextor 3] Fixes in crt0_msxdos_advanced and printf.c

### DIFF
--- a/source/tools/C/printf.c
+++ b/source/tools/C/printf.c
@@ -160,7 +160,12 @@ static int format_string(const char* buf, const char *fmt, va_list ap)
     else if(theChar == 'x') {
       base = 16;
     }
-    else if(theChar != 'd' && theChar != 'i') {
+#ifdef SUPPORT_LONG
+    else if(isLong) {
+      fmtPnt--;
+    } else
+#endif    
+    if(theChar != 'd' && theChar != 'i') {
       do_char_inc(theChar);
       continue;
     }


### PR DESCRIPTION
"Backport" of #135

Part of #164

Note: pull request closed because:

- The fix for error code returned to the OS in `crt0_msxdos_advanced.s` (changing `ld b,l` to `ld b,a`) was already present in the v3.0 branch.
- The change to `printf.c` in the original pull request was actually invalid, the file in the v3.0 branch is already correct.