### PR TITLE
[Nextor 3] Fix "map to device sector 0" option in CALL MAPDRV

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -4411,7 +4411,7 @@ MAPDRV_NOGETCUR:
 	ld	hl,0
 	ld	(MAPDRV_SEC),hl
 	ld	(MAPDRV_SEC+2),hl
-	jr	MAPDRV_GOTPAR
+	jr	MAPDRV_GOT_PAR_SEC
 MAPDRV_NOP0:
 
 	;* If partition number is 2 to 4, convert it to primary or logical
@@ -4468,6 +4468,7 @@ MAPDRV_GOTPAR:
 
 	ld	(MAPDRV_SEC),de
 	ld	(MAPDRV_SEC+2),hl
+MAPDRV_GOT_PAR_SEC:
 
 	;* Perform the mapping
 


### PR DESCRIPTION
"Backport" of #151

Part of #164
