### PR TITLE
[Nextor 3] Modify ZAP_ALL to skip drives assigned to device-based drivers

### DIFF
--- a/source/kernel/bank2/val.mac
+++ b/source/kernel/bank2/val.mac
@@ -2764,6 +2764,13 @@ zap_all_loop:	ld	a,b			;Get logical unit number
 		or	e
 		jr	z,no_zap_unit		;Skip if zero (no unit)
 ;
+		push hl				;Only zap if the unit is not controlled
+		ld de,UD_FLAGS      ;by a device-based driver
+		add hl,de
+		bit UF_DBD,(hl)
+		pop hl
+		jr nz,no_zap_unit
+
 		ld	hl,UD_TIME##
 		add	hl,de			;HL -> UD_TIME byte
 		ld	a,(hl)			;If UD_TIME is non-zero then

--- a/source/kernel/bank2/val.mac
+++ b/source/kernel/bank2/val.mac
@@ -2765,7 +2765,7 @@ zap_all_loop:	ld	a,b			;Get logical unit number
 		jr	z,no_zap_unit		;Skip if zero (no unit)
 ;
 		push hl				;Only zap if the unit is not controlled
-		ld de,UD_DFLAGS      ;by a Nextor driver
+		ld hl,UD_DFLAGS      ;by a Nextor driver
 		add hl,de
 		bit UF_DBD,(hl)
 		pop hl

--- a/source/kernel/bank2/val.mac
+++ b/source/kernel/bank2/val.mac
@@ -2765,7 +2765,7 @@ zap_all_loop:	ld	a,b			;Get logical unit number
 		jr	z,no_zap_unit		;Skip if zero (no unit)
 ;
 		push hl				;Only zap if the unit is not controlled
-		ld de,UD_FLAGS      ;by a device-based driver
+		ld de,UD_DFLAGS      ;by a Nextor driver
 		add hl,de
 		bit UF_DBD,(hl)
 		pop hl


### PR DESCRIPTION
"Backport" of #147

- The semantics change from "when the drive is assigned to a device-based driver" to "when the drive is assigned to a Nextor driver" since device-based is the only type of driver supported by Nextor 3.
- Also fixes a bug in the original implementation: `UD_FLAGS` was being checked instead of `UD_DFLAGS`, and DE was being used instead of HL.

Part of #164