### PR TITLE
[Nextor 3] Activate support for long integers in the printf routine

### DIFF
--- a/source/tools/C/printf.c
+++ b/source/tools/C/printf.c
@@ -24,6 +24,8 @@
    %lx: hexadecimal long
 */
 
+#define SUPPORT_LONG
+
 #include <stdarg.h>
 #include "system.h"
 


### PR DESCRIPTION
"Backport" of #155

Part of #164

Closed because the changes to FDISK don't apply anymore in Nextor 3 (the "test device access" functionality was removed).