### PR TITLE
Change the logic for counting and assigning drives at boot time

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -853,7 +853,7 @@ AUTO_ASSIGN:
 
 	bit AAFLAG_IS_AUTOASPART,d
 	jr nz,DO_AUTO_COMMON
-fofo::
+
 	push hl
 	push bc
 	push de
@@ -1083,7 +1083,14 @@ AA_PX_1ST:
     cp  .IPART
     jp z,AA_PLOOP_END
     or a
-    jp	nz,AA_LLOOP_NEXT	;Not ready or partition not available
+    jr z,AA_PX_POK
+
+    ;F_GPART failed (device not ready):
+    ;Check if device is removable, if so, assign it anyway
+	;(if later the device becomes online a partition will be assigned on first access)
+    bit 7,(ix+AAD_CURR_PART_DEVNUM)
+    jp z,AA_LLOOP_NEXT	;Not removable: try next device
+    jp AA_ASSIGN_OFFLINE_REMOVABLE	;Removable: assign in offline mode
 AA_PX_POK:
 
     ;--- If we are scanning the first partition and bit 0 of status byte is set, try to enter disk emulation mode
@@ -1343,6 +1350,8 @@ AA_DO_ASSIGN:
 	jr z,AA_DO_ASSDOS1
 
 	set	UF_FOK,(iy+UD_DFLAGS##)	;Tell that the partition information is valid
+
+AA_DO_ASSIGN_NO_FOK:
 	ld	b,(iy+UD_SLOT##)
 	ld	c,(iy+UD_PHYSICAL_UNIT##)
 	push	bc
@@ -1415,6 +1424,37 @@ AA_DO_ASSDOS1:
 
 	xor	a
 	ret
+
+
+	;--- Assign a removable device to the drive without partition info.
+	;    The partition will be assigned on first access (by BUILD_UPB).
+	;    This is used when a removable device is offline at boot time.
+	;    Reuses AA_DO_ASSIGN but skips setting UF_FOK for DOS 2 mode.
+
+AA_ASSIGN_OFFLINE_REMOVABLE:
+	ld a,(ix+AAD_CURR_PART_DEVNUM)
+	ld (ix+AAD_CAND_PART_DEVNUM),a
+
+	;Set partition sector to -1
+	;In DOS 1 mode this means "no partition assigned".
+	;Otherwise it doesn't matter since UF_FOK won't be set.
+	ld a,0FFh
+	ld (ix+AAD_CAND_PART_SECTOR),a
+	ld (ix+AAD_CAND_PART_SECTOR+1),a
+	ld (ix+AAD_CAND_PART_SECTOR+2),a
+	ld (ix+AAD_CAND_PART_SECTOR+3),a
+
+	ld l,(ix+AAD_UNIT_DESCRIPTOR)
+	ld h,(ix+AAD_UNIT_DESCRIPTOR+1)
+	push hl
+	pop iy
+
+	;Jump to AA_DO_ASSIGN but skip setting UF_FOK for DOS 2 mode
+	;(UF_FOK not set means BUILD_UPB will auto-assign partition on first access)
+	ld a,(DOS_VER##)
+	or a
+	jp z,AA_DO_ASSDOS1
+	jp AA_DO_ASSIGN_NO_FOK
 
 
     ;Try to enter emulation mode from data in RAM
@@ -5702,34 +5742,94 @@ COUNTDEVS_MAX_DEV_OK:
     ld a,1  ;Only 1 device if "5" key is pressed
     ret
 
-	;Loop through DEVQ_GET_PARAMS for all device numbers, 
-	;return A=Number of devices found (devices for which no error was returned)
+	;Loop through DEVQ_GET_PARAMS for all device numbers,
+	;return A=Number of devices found.
+	;For offline devices, only count them if they are removable.
 	;Input: B = Max device number, D=0
 
 COUNT_DEVICES_LOOP:
+	;Allocate 12-byte buffer on stack for DEVQ_GET_PARAMS response
+	ld hl,-12
+	add hl,sp
+	ld sp,hl
+	push hl			;Save buffer address
+
+COUNTDEVS_LOOP_ITER:
 	push bc
 	push de
-	ld c,b
+
+	;Stack layout:
+	;  SP+0,1: DE (D=count)
+	;  SP+2,3: BC (B=device number)
+	;  SP+4,5: buffer address
+	;  SP+6..17: 12-byte buffer
+
+	ld c,b			;C = device number
+	ld iy,0
+	add iy,sp
+	ld l,(iy+4)
+	ld h,(iy+5)		;HL = buffer address
 	ld ix,DRIVER.DEVICE_QUERY##
 	ld a,DRIVER.DEVQ_GET_PARAMS##
-	ld hl,0
 	ex	af,af'
 	ld	a,DV_BANK##
 	call	CALBNK##
 
-	pop de
-	pop bc
 	or a
-	jr z,COUNTDEVS_DEV_FOUND
-	cp DRIVER.QUERY_NOT_IMPLEMENTED##	;We count "Not implemented" error as "device exists, no info available"
-	jr nz,COUNTDEVS_DEV_NOT_FOUND
+	jr z,COUNTDEVS_PARAMS_OK
+	cp DRIVER.QUERY_NOT_IMPLEMENTED##
+	jr z,COUNTDEVS_DEV_FOUND	;Not implemented = count it
+	jr COUNTDEVS_DEV_NOT_FOUND	;Error = don't count
 
-COUNTDEVS_DEV_FOUND:
-	inc d
+COUNTDEVS_PARAMS_OK:
+	;Extract removable flag from buffer+7 bit 0
+	ld iy,0
+	add iy,sp
+	ld l,(iy+4)
+	ld h,(iy+5)		;HL = buffer address
+	ld bc,7
+	add hl,bc
+	ld a,(hl)
+	and 1
+	ld e,a			;E = removable flag
+
+	;Get device number from stack
+	ld c,(iy+3)		;C = device number
+
+	push de			;Save E=removable
+	ld ix,DRIVER.DEVICE_QUERY##
+	ld a,DRIVER.DEVQ_GET_AVAILABILITY##
+	ex	af,af'
+	ld	a,DV_BANK##
+	call	CALBNK##
+
+	pop de			;E = removable flag
+
+	;Count if: error, or online (B!=0), or removable (E!=0)
+	or a
+	jr nz,COUNTDEVS_DEV_FOUND	;Error = assume online
+	ld a,b
+	or e			;Online (B!=0) or removable (E!=0)?
+	jr nz,COUNTDEVS_DEV_FOUND
+	;Offline and not removable: don't count
 
 COUNTDEVS_DEV_NOT_FOUND:
-	djnz COUNT_DEVICES_LOOP
+	pop de
+	pop bc
+	djnz COUNTDEVS_LOOP_ITER
+	jr COUNTDEVS_EXIT
 
+COUNTDEVS_DEV_FOUND:
+	pop de
+	pop bc
+	inc d
+	djnz COUNTDEVS_LOOP_ITER
+
+COUNTDEVS_EXIT:
+	pop hl			;Discard saved buffer address
+	ld hl,12
+	add hl,sp
+	ld sp,hl		;Deallocate 12-byte buffer
 	ld a,d
 	ret
 

--- a/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
+++ b/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
@@ -242,34 +242,6 @@ DRV_NAME:
 ; to the Nextor v3 driver structure
 
 
-	;Output a string
-	;Input:  HL = String
-	;        DE = Destination
-	;        B  = Max length including terminator
-	;Output: A  = QUERY_OK or QUERY_TRUNCATED_STRING
-	;        DE = Pointer to the 0
-	
-OUTPUT_STRING:
-	ld a,b
-	or a
-	ret z
-
-OUTPUT_STRING_LOOP:
-	ld a,(hl)
-	or a
-	ld (de),a
-	ret z
-
-	inc hl
-	inc de
-	djnz OUTPUT_STRING
-
-    dec de
-	xor a
-	ld (de),a
-	ld a,QUERY_TRUNCATED_STRING
-	ret
-
 
 	;--- Driver query
 	;    Input:  A = Query index
@@ -989,7 +961,7 @@ NEXTOR2_DEV_INFO:
 		call SD_OFF
 		ei
 .DEV_INFO_BAD_DEVICE:
-		ld a,QUERY_INVALID_DEVICE
+		ld a,QUERY_NOT_IMPLEMENTED
 		ret
 
 
@@ -1247,7 +1219,7 @@ NEXTOR2_LUN_INFO:
 	ld	(hl),d
 	inc	hl
 
-	ld	(hl),1	; +7: Flags
+	ld	(hl),1	; +7: Flags (removable device)
 	inc	hl
 	
 	ld	(hl),0	; +8 Cylinders
@@ -2189,6 +2161,35 @@ PRINT:
 	inc	de
 	jr	PRINT
 
+;-----------------------------------------------------------------------------
+	;Output a string
+	;Input:  HL = String
+	;        DE = Destination
+	;        B  = Max length including terminator
+	;Output: A  = QUERY_OK or QUERY_TRUNCATED_STRING
+	;        DE = Pointer to the 0
+;-----------------------------------------------------------------------------
+
+OUTPUT_STRING:
+	ld a,b
+	or a
+	ret z
+
+OUTPUT_STRING_LOOP:
+	ld a,(hl)
+	or a
+	ld (de),a
+	ret z
+
+	inc hl
+	inc de
+	djnz OUTPUT_STRING
+
+    dec de
+	xor a
+	ld (de),a
+	ld a,QUERY_TRUNCATED_STRING
+	ret
 
 ;-----------------------------------------------------------------------------
 ; Includes

--- a/source/kernel/drivers/SunriseIDE/driver.mac
+++ b/source/kernel/drivers/SunriseIDE/driver.mac
@@ -1650,7 +1650,7 @@ LUN_INFO_SSIZE:
 	;Set other parameters
 
 	ld	(ix),0	;Block device
-	ld	(ix+7),0	;Non removable device nor LUN
+	ld	(ix+7),1	;Removable device
 
 	call	IDE_OFF
 	xor	a

--- a/source/tools/C/drvtest.c
+++ b/source/tools/C/drvtest.c
@@ -27,9 +27,9 @@
 #define REGS_BUFFER ((int*)0x8100)
 #define STRING_BUFFER_ADDRESS 0x8200
 #define STRING_BUFFER ((byte*)STRING_BUFFER_ADDRESS)
-#define DEV_PARAMS ((deviceInfo*)STRING_BUFFER_ADDRESS);
+#define DEV_PARAMS ((deviceInfo*)STRING_BUFFER_ADDRESS)
+#define deviceInfoBuffer ((deviceParams*)STRING_BUFFER_ADDRESS)
 
-__at STRING_BUFFER_ADDRESS deviceParams* deviceInfoBuffer;
 
 /* Some handy code defines */
 
@@ -488,7 +488,7 @@ void DoDeviceQueries()
                 printf("Unknown (%u)\r\n", deviceInfoBuffer->mediumType);
         }
         printf("  Sector size:  %u (0x%x)\r\n", deviceInfoBuffer->sectorSize, deviceInfoBuffer->sectorSize);
-        printf("  Sector count: %lu (0x%lx)\r\n", deviceInfoBuffer->sectorCount, deviceInfoBuffer->sectorSize);
+        printf("  Sector count: %lu (0x%lx)\r\n", deviceInfoBuffer->sectorCount, deviceInfoBuffer->sectorCount);
 
         flags = deviceInfoBuffer->flags;
         print("  Flags:\r\n");


### PR DESCRIPTION
## Changes in the kernel

**Before:** All the existing devices got counted towards the drive count, but offline devices weren't assigned a drive letter. Thus
gaps in the sequence of drive letters could appear.

**After:** Only devices that at boot time are either online OR are offline but are removable are counted towards the drive count. Also removable offline devices get assigned a drive letter anyway.

### Example 1

First driver has 2 devices, 1 is online, 2 is removable and offline.

Before:

-  A: is assigned to device 1
-  B: is reserved but not assigned
-  C: is assigned to next driver

After:

-  A: is assigned to device 1
-  B: is assigned to device 2 (without partition assigned)
-  C: is assigned to next driver

### Example 2

First driver has 2 devices, 1 is online, 2 is fixed and offline.

Before: same as previous example.

After:

-  A: is assigned to device 1
-  B: is assigned to next driver


## Changes in drivers

- MFRSD: The device information routine will return `QUERY_NOT_IMPLEMENTED` instead of `QUERY_INVALID_DEVICE` when the device is offline (since the device still exists, just not ready).
- Sunrise IDE: Always report devices as removable since we don't really know if they are or not.


## Additional changes

Small fixes in the `drvtest` tool.
