### PR TITLE
Fixes for DOS 1 mode and more

### DIFF
--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -353,7 +353,7 @@ B0RELS = $(addprefix bank0/,doshead.rel 40ff.rel b0.rel init.rel alloc.rel dskba
 B1RELS = $(addprefix bank1/,dosinit.rel mapinit.rel msg.rel)
 B2RELS = $(addprefix bank2/,kinit.rel char.rel dev.rel kbios.rel misc.rel seg.rel path.rel find.rel dir.rel handles.rel del.rel rw.rel files.rel buf.rel fat.rel val.rel err.rel)
 B3RELS = $(addprefix bank3/,dos1ker.rel)
-B4RELS = $(addprefix bank4/,jump.rel env.rel cpm.rel partit.rel ramdrv.rel time.rel seg.rel misc.rel dskab.rel)
+B4RELS = $(addprefix bank4/,jump.rel env.rel cpm.rel ramdrv.rel time.rel seg.rel misc.rel dskab.rel)
 B5RELS = $(addprefix bank5/,b5.rel)
 B6RELS = $(addprefix bank6/,b6.rel)
 
@@ -362,7 +362,7 @@ lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(s
 	$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 .SECONDEXPANSION:
-$(COMRELS) $(B0RELS) $(B1RELS) $(B2RELS) $(B3RELS) $(B4RELS) $(B5RELS) $(B6RELS) drv.rel rel.rel: \
+$(COMRELS) $(B0RELS) $(B1RELS) $(B2RELS) $(B3RELS) $(B4RELS) partit.rel $(B5RELS) $(B6RELS) drv.rel rel.rel: \
 	macros.inc \
 	const.inc \
 	condasm.inc \
@@ -484,6 +484,12 @@ bank4/b4.rel: \
 
 	$(call assemble,bank4/b4.mac)
 
+bank4/partit.rel: \
+	bank4/partit.mac \
+	bank0/b0labels.inc
+
+	$(call assemble,bank4/partit.mac)
+
 bank4/ramdrvh.rel: \
 	macros.inc \
 	const.inc \
@@ -503,6 +509,7 @@ bank4/B4RD.BIN: \
 bank4/B4.BIN bank4/B4.SYM: \
 	$(COMRELS) \
 	$(B4RELS) \
+	bank4/partit.rel \
 	bank4/b4.rel \
 	bank4/ramdrv.rel \
 	bank0/b0labels.inc \

--- a/source/kernel/bank0/dskbasic.mac
+++ b/source/kernel/bank0/dskbasic.mac
@@ -727,6 +727,14 @@ DO_FDISK_OK:
 	call	CALBNK##
 	pop	hl
 
+	;In DOS 1 mode FDISK is called via CALBNK from bank 3's DO_FDISK.
+	;So here we just return and the calling code will take care of
+	;executing the NEW statement. This way bank 3 will remain active.
+
+	ld	a,(MAIN_BANK##)
+	or	a
+	ret	nz
+
 	ld	hl,NEWTXT
 	ld	de,09000h
 	ld	bc,3

--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -2698,10 +2698,11 @@ MK_DVB_TBL:
 	ld	b,a	;B = Number of entries in the table
 	add	a,a
 	add	a,a
-	add	a,a
+	add	a,a ;A = B*8
+	sub b ;Now A = B*7
 	ld	l,a
 	ld	h,0
-	inc	hl	;HL = Size of table = (entries * 8) + 1
+	inc	hl	;HL = Size of table = (entries * UD1_SIZE) + 1
 	push	hl
 	call	ALLOC##
 	pop	bc

--- a/source/kernel/bank3/dos1ker.mac
+++ b/source/kernel/bank3/dos1ker.mac
@@ -8847,7 +8847,22 @@ DO_FDISK:
 	call	CALBNK##
 
 	pop	hl
-	ret
+
+	;Execute NEW and return to BASIC.
+	;FDISK:: in bank 0 returns normally in DOS 1 mode
+	;(instead of doing jp CALBAS) so that CALBNK properly
+	;restores bank 3 first.
+
+	ld	hl,NEWTXT_DOS1
+	ld	de,09000h
+	ld	bc,3
+	ldir
+	ld	hl,09000h
+	ld	ix,NEWSTT
+	jp	CALBAS
+
+NEWTXT_DOS1:
+	db	3ah, 94h, 0	; ":NEW"
 
 
 ; Extra CALL handlers.

--- a/source/kernel/bank3/dos1ker.mac
+++ b/source/kernel/bank3/dos1ker.mac
@@ -8741,7 +8741,7 @@ A7397:
 
 	defb	31,28,31,30,31,30,31,31,30,31,30,31
 
-BOOTKEYS equ 0F992h    ;Defined in kvar.mac
+BOOTKEYS equ 0F9B9h    ;Defined in kvar.mac
 
 TO_BASIC_REQUIRED:
 	LD	A,0FFH

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -608,7 +608,7 @@ AUTODRV_DRVLOOP:
 	ld	hl,(KERNEX_DOS1##)
 	inc	(hl)		;Increment size of table
 	pop	ix
-	ld de,8
+	ld de,UD1_SIZE##
 	add ix,de		;Point to next entry in table
 	pop	iy
 	pop	bc
@@ -949,7 +949,7 @@ AA_CHKDUP_DOS1:
 	inc	iy
 
 AA_CHKDUP_LOOP1:
-	ld	a,(iy+UD_SLOT##)
+	ld	a,(iy+UD1_SLOT##)
 	cp	(ix+AAD_DRIVER_SLOT)
 	jr	nz,AA_CHKDUP_NEXT1
 
@@ -963,7 +963,7 @@ AA_CHKDUP_LOOP1:
 
 AA_CHKDUP_NEXT1:
 	ld	a,b
-	ld	bc,8
+	ld	bc,UD1_SIZE##
 	add	iy,bc
 	ld	b,a
 	djnz	AA_CHKDUP_LOOP1
@@ -3634,62 +3634,55 @@ MAPDOS1_NODEF:
 
 	;* First check that the same drive and partition is not mapped to another drive
 
-	ld	a,(ix+2)
+	ld	a,(ix+UD1_DEVICE_NUMBER##)
 	push	af
-	ld	(ix+2),0	;At the moment leave the drive unmapped
+	ld	(ix+UD1_DEVICE_NUMBER##),0	;At the moment leave the drive unmapped
 	push	ix
 
 	ld	ix,(KERNEX_DOS1)
 	inc	ix
 	ld	b,(ix-1)
 MAPDOS1_CHECK_LOOP:
-	ld	a,(ix)	;Check slot number
+	ld	a,(ix+UD1_SLOT##)	;Check slot number
 	cp	(iy)
 	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+2)	;Check device number
+	ld	a,(ix+UD1_DEVICE_NUMBER##)	;Check device number
 	cp	(iy+2)
 	jr	nz,MAPDOS1_CHK_NEXT
 
-	ld	a,(ix+3)	;Check starting sector
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##)	;Check starting sector
 	cp	(iy+3)
 	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+4)
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+1)
 	cp	(iy+4)
 	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+5)
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+2)
 	cp	(iy+5)
 	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+6)
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+3)
 	cp	(iy+6)
-	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+7)
-	cp	(iy+7)
 	jr	nz,MAPDOS1_CHK_NEXT
 
 	pop	ix
 	pop	af
-	ld	(ix+2),a	;Leave old partition mapped
+	ld	(ix+UD1_DEVICE_NUMBER##),a	;Leave old partition mapped
 	ld	a,.PUSED##
 	ret
 
 MAPDOS1_CHK_NEXT:
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
+	push	bc
+	ld	bc,UD1_SIZE##
+	add	ix,bc
+	pop	bc
 	djnz	MAPDOS1_CHECK_LOOP
 
 	pop	ix
 	pop	af
-	ld	(ix+2),a	;Leave old partition mapped
+	ld	(ix+UD1_DEVICE_NUMBER##),a	;Leave old partition mapped
 
 	;* Now check that the specified driver and device are valid
 
-	ld	a,(ix)	;Error if slot in parameters block is not the same already assigned
+	ld	a,(ix+UD1_SLOT##)	;Error if slot in parameters block is not the same already assigned
 	cp	(iy)
 	ld	a,.IDRVR##
 	ret	nz
@@ -3726,15 +3719,15 @@ MAPDOS1_CHK_NEXT:
 
 	pop	ix
 	ld	a,(iy+2)
-	ld	(ix+2),a	;Device number
+	ld	(ix+UD1_DEVICE_NUMBER##),a	;Device number
 	ld	a,(iy+4)
-	ld	(ix+3),a	;First sector
+	ld	(ix+UD1_FIRST_ABSOLUTE_SECTOR##),a	;First sector
 	ld	a,(iy+5)
-	ld	(ix+4),a
+	ld	(ix+UD1_FIRST_ABSOLUTE_SECTOR##+1),a
 	ld	a,(iy+6)
-	ld	(ix+5),a
+	ld	(ix+UD1_FIRST_ABSOLUTE_SECTOR##+2),a
 	ld	a,(iy+7)
-	ld	(ix+6),a
+	ld	(ix+UD1_FIRST_ABSOLUTE_SECTOR##+3),a
 
 MAPDOS1_END_OK:
 	set	7,(ix+UD1_RELATIVE_DRIVE##)	;Set partition changed flag
@@ -5666,12 +5659,12 @@ GET_DVB_POINTER:
 	inc	ix
 	ld	b,(ix-1)
 GET_DVB_LOOP:
-	ld	a,(ix)	;Driver slot
+	ld	a,(ix+UD1_SLOT##)	;Driver slot
 	and 10001111b
 	cp	e
 	jr	nz,GET_DVB_NEXT
 
-	ld	a,(ix+1)	;Relative unit for driver
+	ld	a,(ix+UD1_RELATIVE_DRIVE##)	;Relative unit for driver
 	and	01111111b	;Clear "partition changed" flag
 	cp	c
 	jr	nz,GET_DVB_NEXT
@@ -5680,13 +5673,10 @@ GET_DVB_LOOP:
 	ret
 
 GET_DVB_NEXT:
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
-	inc	ix
+	push	bc
+	ld	bc,UD1_SIZE##
+	add	ix,bc
+	pop	bc
 	djnz	GET_DVB_LOOP
 
 	scf
@@ -5992,11 +5982,11 @@ CMIU_DOS1:
 	inc	iy
 
 CMIU1_LOOP:
-	ld	a,(iy)
+	ld	a,(iy+UD1_SLOT##)
 	cp	h
 	jr	nz,CMIU1_NEXT
 
-	ld	a,(iy+2)
+	ld	a,(iy+UD1_DEVICE_NUMBER##)
 	or	a			;If device number is 0, it is an unused table entry
 	jr	z,CMIU1_NEXT
 	cp	d
@@ -6004,16 +5994,16 @@ CMIU1_LOOP:
 
 	exx
 
-	ld  a,(iy+4)
+	ld  a,(iy+UD1_FIRST_ABSOLUTE_SECTOR##)
 	cp e
 	jr nz,CMIU1_NEXXT
-	ld  a,(iy+5)
+	ld  a,(iy+UD1_FIRST_ABSOLUTE_SECTOR##+1)
 	cp d
 	jr nz,CMIU1_NEXXT
-	ld  a,(iy+6)
+	ld  a,(iy+UD1_FIRST_ABSOLUTE_SECTOR##+2)
 	cp l
 	jr nz,CMIU1_NEXXT
-	ld  a,(iy+7)
+	ld  a,(iy+UD1_FIRST_ABSOLUTE_SECTOR##+3)
 	cp h
 	jr nz,CMIU1_NEXXT
 
@@ -6026,7 +6016,7 @@ CMIU1_NEXXT:
 	exx
 CMIU1_NEXT:
 	ld	a,b
-	ld	bc,8
+	ld	bc,UD1_SIZE##
 	add	iy,bc
 	ld	b,a
 	djnz	CMIU1_LOOP

--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -790,7 +790,7 @@ DIO_OK:
 
 DIO_NEXT:
 	push	bc
-	ld	bc,8
+	ld	bc,UD1_SIZE##
 	add	iy,bc
 	pop	bc
 	djnz	IS_DVB_LOOP

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -281,7 +281,14 @@ size	macro	name
     field  EMU_DESC_SIZE,EMU_TMP   ;Temporary location of work area used when setting up disk emulation mode
     field  1,IN_EMU_MODE           ;Set to 1 when disk emulation mode has been entered
     field  2,EMU_WORK_AREA_ADDRESS ;Address of work area as read from the emulation data file
-    ;NOTE! BOOTKEYS is used in dos1ker.mac, it must be manually updated if it changes
+
+    ;The KERNEX_DOS1 table (1 + max 8 entries of UD1_SIZE bytes each = up to 57 bytes)
+    ;is also written at BOOT_TMP, overlapping with the fields above plus 40 more bytes.
+    ;BOOTKEYS and I_AM_RUSSIAN must be placed past the maximum table extent.
+    field  40                      ;Padding to avoid KERNEX_DOS1 table overlap
+
+    ;NOTE! BOOTKEYS is used in dos1ker.mac with a hardcoded address,
+    ;it must be manually updated there if it changes.
     field  5,BOOTKEYS              ;To store the state of boot keys
     field  1,I_AM_RUSSIAN
 ;


### PR DESCRIPTION
* Various parts of the code were assuming that the size of `KERNEX_DOS1` entries (`UD1_SIZE` constant) was still 8 (so including the LUN number), causing  crashes and incorrect behavior in DOS 1 mode. Fixed, and modified the code to use the `UD1_*` contants instead of hardcoded structure sizes and offsets.
* Fix: same temporary buffer being used for the boot keys information and for building the `KERNEX_DOS1` table, causing ghost key pressings.
* Fix: any BASIC command crashing the computer after FDISK in DOS 1 mode.
* Fix: kernel makefile not taking in account changes in `b0labels.inc`.
