### PR TITLE
Add a build option to exclude undocumented Z80 opcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ source/tools/data.mac
 *conflicto*.*
 *.sln
 *.suo
+.undoc-mode-*
 NEXTOR.SYS
 NEXTORK.SYS
 nextor_base.dat

--- a/sdk/asm/macros/undoc.inc
+++ b/sdk/asm/macros/undoc.inc
@@ -1,0 +1,1398 @@
+;-----------------------------------------------------------------------------
+;
+; Macros that replace the undocumented Z80 instructions which operate on
+; the high or low halves of the IX and IY registers (ixh, ixl, iyh, iyl).
+;
+; When the symbol NO_UNDOC_CPU_INSTRUCTIONS is defined at assembly time
+; (e.g. via N80's `--define-symbols NO_UNDOC_CPU_INSTRUCTIONS` flag), each
+; macro expands to a sequence of documented instructions that has the same
+; effect on registers AND flags as the original undocumented opcode.
+; Otherwise the macro expands to the original undocumented opcode.
+;
+; This allows a single source tree to produce ROMs that run on the
+; original Z80 (where the undocumented opcodes are smaller and faster) and
+; on Z180-based MSX machines (e.g. Victor HC-95) that do not support them,
+; just by toggling a build flag.
+;
+; Supported macros and operand combinations:
+;
+;   ld_  a,{ixh|ixl|iyh|iyl}
+;   ld_  {b|c|d|e},{ixh|ixl|iyh|iyl}
+;   ld_  ixh,{a|b|c|d|e|<n>}     (n = 8-bit immediate)
+;   ld_  ixl,{a|b|c|d|e|<n>}
+;   ld_  iyh,{a|b|c|d|e|<n>}
+;   ld_  iyl,{a|b|c|d|e|<n>}
+;   ld_  ix,de                   (compound: ld_ ixl,e + ld_ ixh,d)
+;   ld_  iy,de                   (compound: ld_ iyl,e + ld_ iyh,d)
+;
+;   cp_  {ixh|ixl|iyh|iyl}
+;   or_  {ixh|ixl|iyh|iyl}
+;   and_ {ixh|ixl|iyh|iyl}
+;   xor_ {ixh|ixl|iyh|iyl}
+;   add_ a,{ixh|ixl|iyh|iyl}
+;   adc_ a,{ixh|ixl|iyh|iyl}
+;   sub_ {ixh|ixl|iyh|iyl}
+;   sbc_ a,{ixh|ixl|iyh|iyl}
+;
+;   inc_ {ixh|ixl|iyh|iyl}
+;   dec_ {ixh|ixl|iyh|iyl}
+;
+; Operand names are matched case-insensitively (via `ifidni`), so for
+; example `LD_ IYH,A` is equivalent to `ld_ iyh,a`. Any combination
+; not listed above is rejected at assembly time with `.error`.
+;
+; ---------------------------------------------------------------------------
+; Replacement strategy
+; ---------------------------------------------------------------------------
+;
+; A single-instruction undocumented opcode that touches an index half
+; (e.g. `ld iyh,a`) is replaced by the documented sequence
+;
+;       push  iy
+;       ex    (sp),hl   ; HL = original IY,  stack top = original HL
+;       <op via h or l>
+;       ex    (sp),hl   ; HL restored,       stack top = new IY value
+;       pop   iy        ; IY = new value
+;
+; This is 7 bytes / ~71 T-states, vs 2 bytes / 8 T-states for the
+; original undocumented opcode. Flags are preserved exactly because
+; `push`, `pop` and `ex (sp),hl` do not touch them; only the inner
+; `<op>` (which is the documented counterpart of the original) sets
+; flags as the original would. The HL and stack top are temporarily
+; clobbered, but both are restored before the macro returns.
+;
+; The compound `ld_ iy,de` / `ld_ ix,de` shortcuts expand to a single
+; `push de` + `pop iy/ix` (3 bytes / 25 T-states), which is far smaller
+; than two independent `ld_ iyl,e` / `ld_ iyh,d` expansions.
+;
+; IMPORTANT: Do not rewrite a replacement to "save bytes" by using AF
+; as scratch (`push af / ld a,h / ... / pop af`). That would corrupt the
+; flag register if the instruction being replaced is in the middle of a
+; conditional flow — and several Nextor sites depend on flag preservation
+; around these instructions (e.g. the `cp iyh` chain in bank0/init.mac).
+;
+;-----------------------------------------------------------------------------
+
+	ifndef _SDK_UNDOC_MACROS
+_SDK_UNDOC_MACROS equ 1
+
+
+;-----------------------------------------------------------------------------
+; Internal helper: emit a pass-1 .error with a descriptive message.
+
+_undoc_err macro text
+	if1
+	 .error text
+	endif
+	endm
+
+
+;=============================================================================
+; ld_ dest,src
+;=============================================================================
+;
+; Each combination is matched explicitly. Unknown combinations produce
+; `.error`. The flag `_undoc_ld_ok` (defl) is set to 1 by any matching
+; branch and checked at the end of the macro.
+
+ld_ macro dest,src
+	_undoc_ld_ok defl 0
+
+;--- ld a, {ixh|ixl|iyh|iyl}
+
+	ifidni <dest>,<a>
+
+	 ifidni <src>,<ixh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	a,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	a,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	a,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	a,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	a,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	a,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	a,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	a,iyl
+	  endif
+	 endif
+
+	endif
+
+;--- ld b, {ixh|ixl|iyh|iyl}
+
+	ifidni <dest>,<b>
+
+	 ifidni <src>,<ixh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	b,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	b,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	b,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	b,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	b,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	b,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	b,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	b,iyl
+	  endif
+	 endif
+
+	endif
+
+;--- ld c, {ixh|ixl|iyh|iyl}
+
+	ifidni <dest>,<c>
+
+	 ifidni <src>,<ixh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	c,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	c,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	c,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	c,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	c,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	c,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	c,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	c,iyl
+	  endif
+	 endif
+
+	endif
+
+;--- ld d, {ixh|ixl|iyh|iyl}
+
+	ifidni <dest>,<d>
+
+	 ifidni <src>,<ixh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	d,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	d,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	d,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	d,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	d,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	d,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	d,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	d,iyl
+	  endif
+	 endif
+
+	endif
+
+;--- ld e, {ixh|ixl|iyh|iyl}
+
+	ifidni <dest>,<e>
+
+	 ifidni <src>,<ixh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	e,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	e,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	e,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	e,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	e,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	e,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	e,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	e,iyl
+	  endif
+	 endif
+
+	endif
+
+;--- ld {ixh|ixl|iyh|iyl}, src
+;
+; For these we accept any source the documented `ld h,X` / `ld l,X`
+; would accept: registers a/b/c/d/e and 8-bit immediates. Each block
+; enumerates the recognized register sources and falls back to "assume
+; immediate" for anything else.
+
+	ifidni <dest>,<ixh>
+
+	 ifidni <src>,<a>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	h,a
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixh,a
+	  endif
+	 endif
+
+	 ifidni <src>,<b>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	h,b
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixh,b
+	  endif
+	 endif
+
+	 ifidni <src>,<c>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	h,c
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixh,c
+	  endif
+	 endif
+
+	 ifidni <src>,<d>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	h,d
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixh,d
+	  endif
+	 endif
+
+	 ifidni <src>,<e>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	h,e
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixh,e
+	  endif
+	 endif
+
+	 if _undoc_ld_ok eq 0  ;; assume immediate
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	h,src
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixh,src
+	  endif
+	 endif
+
+	endif
+
+	ifidni <dest>,<ixl>
+
+	 ifidni <src>,<a>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	l,a
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixl,a
+	  endif
+	 endif
+
+	 ifidni <src>,<b>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	l,b
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixl,b
+	  endif
+	 endif
+
+	 ifidni <src>,<c>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	l,c
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixl,c
+	  endif
+	 endif
+
+	 ifidni <src>,<d>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	l,d
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixl,d
+	  endif
+	 endif
+
+	 ifidni <src>,<e>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	l,e
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixl,e
+	  endif
+	 endif
+
+	 if _undoc_ld_ok eq 0  ;; assume immediate
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   ld	l,src
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   ld	ixl,src
+	  endif
+	 endif
+
+	endif
+
+	ifidni <dest>,<iyh>
+
+	 ifidni <src>,<a>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	h,a
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyh,a
+	  endif
+	 endif
+
+	 ifidni <src>,<b>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	h,b
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyh,b
+	  endif
+	 endif
+
+	 ifidni <src>,<c>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	h,c
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyh,c
+	  endif
+	 endif
+
+	 ifidni <src>,<d>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	h,d
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyh,d
+	  endif
+	 endif
+
+	 ifidni <src>,<e>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	h,e
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyh,e
+	  endif
+	 endif
+
+	 if _undoc_ld_ok eq 0  ;; assume immediate
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	h,src
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyh,src
+	  endif
+	 endif
+
+	endif
+
+	ifidni <dest>,<iyl>
+
+	 ifidni <src>,<a>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	l,a
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyl,a
+	  endif
+	 endif
+
+	 ifidni <src>,<b>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	l,b
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyl,b
+	  endif
+	 endif
+
+	 ifidni <src>,<c>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	l,c
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyl,c
+	  endif
+	 endif
+
+	 ifidni <src>,<d>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	l,d
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyl,d
+	  endif
+	 endif
+
+	 ifidni <src>,<e>
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	l,e
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyl,e
+	  endif
+	 endif
+
+	 if _undoc_ld_ok eq 0  ;; assume immediate
+	  _undoc_ld_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   ld	l,src
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   ld	iyl,src
+	  endif
+	 endif
+
+	endif
+
+;--- ld iy,de  /  ld ix,de  (compound shortcuts: 3 bytes vs 14)
+
+	ifidni <dest>,<iy>
+
+	 ifidni <src>,<de>
+	  _undoc_ld_ok defl 1
+	  push	de
+	  pop	iy
+	 endif
+
+	endif
+
+	ifidni <dest>,<ix>
+
+	 ifidni <src>,<de>
+	  _undoc_ld_ok defl 1
+	  push	de
+	  pop	ix
+	 endif
+
+	endif
+
+;--- Final validation
+
+	if _undoc_ld_ok eq 0
+	 _undoc_err <ld_: invalid operand combination>
+	endif
+	endm
+
+
+;=============================================================================
+; cp_ src    -    cp {ixh|ixl|iyh|iyl}
+;=============================================================================
+
+cp_ macro src
+	_undoc_op_ok defl 0
+
+	ifidni <src>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  cp	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  cp	ixh
+	 endif
+	endif
+
+	ifidni <src>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  cp	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  cp	ixl
+	 endif
+	endif
+
+	ifidni <src>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  cp	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  cp	iyh
+	 endif
+	endif
+
+	ifidni <src>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  cp	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  cp	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <cp_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+
+;=============================================================================
+; or_ src     and_ src     xor_ src     sub_ src
+;=============================================================================
+;
+; Single-operand ALU instructions on an index half register.
+; The operation is performed against accumulator A; the result goes to A
+; and the flags are updated as documented for the corresponding documented
+; instruction.
+
+or_ macro src
+	_undoc_op_ok defl 0
+
+	ifidni <src>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  or	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  or	ixh
+	 endif
+	endif
+
+	ifidni <src>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  or	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  or	ixl
+	 endif
+	endif
+
+	ifidni <src>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  or	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  or	iyh
+	 endif
+	endif
+
+	ifidni <src>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  or	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  or	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <or_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+and_ macro src
+	_undoc_op_ok defl 0
+
+	ifidni <src>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  and	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  and	ixh
+	 endif
+	endif
+
+	ifidni <src>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  and	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  and	ixl
+	 endif
+	endif
+
+	ifidni <src>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  and	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  and	iyh
+	 endif
+	endif
+
+	ifidni <src>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  and	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  and	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <and_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+xor_ macro src
+	_undoc_op_ok defl 0
+
+	ifidni <src>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  xor	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  xor	ixh
+	 endif
+	endif
+
+	ifidni <src>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  xor	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  xor	ixl
+	 endif
+	endif
+
+	ifidni <src>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  xor	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  xor	iyh
+	 endif
+	endif
+
+	ifidni <src>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  xor	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  xor	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <xor_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+sub_ macro src
+	_undoc_op_ok defl 0
+
+	ifidni <src>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  sub	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  sub	ixh
+	 endif
+	endif
+
+	ifidni <src>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  sub	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  sub	ixl
+	 endif
+	endif
+
+	ifidni <src>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  sub	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  sub	iyh
+	 endif
+	endif
+
+	ifidni <src>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  sub	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  sub	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <sub_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+
+;=============================================================================
+; add_ a,src    adc_ a,src    sbc_ a,src
+;=============================================================================
+
+add_ macro dest,src
+	_undoc_op_ok defl 0
+
+	ifidni <dest>,<a>
+
+	 ifidni <src>,<ixh>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   add	a,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   add	a,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   add	a,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   add	a,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   add	a,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   add	a,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   add	a,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   add	a,iyl
+	  endif
+	 endif
+
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <add_: only `add_ a,{ixh|ixl|iyh|iyl}` is supported>
+	endif
+	endm
+
+adc_ macro dest,src
+	_undoc_op_ok defl 0
+
+	ifidni <dest>,<a>
+
+	 ifidni <src>,<ixh>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   adc	a,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   adc	a,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   adc	a,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   adc	a,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   adc	a,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   adc	a,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   adc	a,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   adc	a,iyl
+	  endif
+	 endif
+
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <adc_: only `adc_ a,{ixh|ixl|iyh|iyl}` is supported>
+	endif
+	endm
+
+sbc_ macro dest,src
+	_undoc_op_ok defl 0
+
+	ifidni <dest>,<a>
+
+	 ifidni <src>,<ixh>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   sbc	a,h
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   sbc	a,ixh
+	  endif
+	 endif
+
+	 ifidni <src>,<ixl>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	ix
+	   ex	(sp),hl
+	   sbc	a,l
+	   ex	(sp),hl
+	   pop	ix
+	  else
+	   sbc	a,ixl
+	  endif
+	 endif
+
+	 ifidni <src>,<iyh>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   sbc	a,h
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   sbc	a,iyh
+	  endif
+	 endif
+
+	 ifidni <src>,<iyl>
+	  _undoc_op_ok defl 1
+	  ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	   push	iy
+	   ex	(sp),hl
+	   sbc	a,l
+	   ex	(sp),hl
+	   pop	iy
+	  else
+	   sbc	a,iyl
+	  endif
+	 endif
+
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <sbc_: only `sbc_ a,{ixh|ixl|iyh|iyl}` is supported>
+	endif
+	endm
+
+
+;=============================================================================
+; inc_ reg    dec_ reg
+;=============================================================================
+;
+; The original `inc ixh` etc. set Z, S, P/V (overflow), H and N as a
+; documented `inc h` would; only the C flag is left untouched. The
+; replacement uses `inc h` (or `inc l`) inside the push/pop wrapper so
+; the same flag effect is preserved.
+
+inc_ macro reg
+	_undoc_op_ok defl 0
+
+	ifidni <reg>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  inc	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  inc	ixh
+	 endif
+	endif
+
+	ifidni <reg>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  inc	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  inc	ixl
+	 endif
+	endif
+
+	ifidni <reg>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  inc	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  inc	iyh
+	 endif
+	endif
+
+	ifidni <reg>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  inc	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  inc	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <inc_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+dec_ macro reg
+	_undoc_op_ok defl 0
+
+	ifidni <reg>,<ixh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  dec	h
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  dec	ixh
+	 endif
+	endif
+
+	ifidni <reg>,<ixl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	ix
+	  ex	(sp),hl
+	  dec	l
+	  ex	(sp),hl
+	  pop	ix
+	 else
+	  dec	ixl
+	 endif
+	endif
+
+	ifidni <reg>,<iyh>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  dec	h
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  dec	iyh
+	 endif
+	endif
+
+	ifidni <reg>,<iyl>
+	 _undoc_op_ok defl 1
+	 ifdef NO_UNDOC_CPU_INSTRUCTIONS
+	  push	iy
+	  ex	(sp),hl
+	  dec	l
+	  ex	(sp),hl
+	  pop	iy
+	 else
+	  dec	iyl
+	 endif
+	endif
+
+	if _undoc_op_ok eq 0
+	 _undoc_err <dec_: operand must be ixh, ixl, iyh or iyl>
+	endif
+	endm
+
+
+	endif    ;_SDK_UNDOC_MACROS

--- a/source/Makefile
+++ b/source/Makefile
@@ -3,15 +3,17 @@
 # The generated files will be copied to bin/kernels and bin/tools.
 # The makefiles on each directory can be used independently as well.
 #
-# Set NO_UNDOC_CPU_INSTRUCTIONS=1 to build a Z180-compatible variant
-# in which the kernel and tools avoid all undocumented Z80 opcodes
-# (those that operate on the high or low halves of IX/IY). See
-# sdk/asm/macros/undoc.inc for details.
+# Set NO_UNDOC_CPU_INSTRUCTIONS=1 to build a Z180-compatible kernel
+# variant that avoids all undocumented Z80 opcodes (those that operate
+# on the high or low halves of IX/IY). See sdk/asm/macros/undoc.inc
+# for details. The flag is propagated only to the kernel sub-build;
+# NEXTOR.SYS and the .COM tools contain no undoc opcodes so the flag
+# has no effect on them.
 
 all:
 	$(MAKE) -C kernel NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS)
-	$(MAKE) -C command/msxdos NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS)
-	$(MAKE) -C tools NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS)
+	$(MAKE) -C command/msxdos
+	$(MAKE) -C tools
 	$(MAKE) -C tools/C
 
 .PHONY: clean

--- a/source/Makefile
+++ b/source/Makefile
@@ -2,11 +2,16 @@
 # It will build the kernel ROM files, NEXTOR.SYS and the command line tools.
 # The generated files will be copied to bin/kernels and bin/tools.
 # The makefiles on each directory can be used independently as well.
+#
+# Set NO_UNDOC_CPU_INSTRUCTIONS=1 to build a Z180-compatible variant
+# in which the kernel and tools avoid all undocumented Z80 opcodes
+# (those that operate on the high or low halves of IX/IY). See
+# sdk/asm/macros/undoc.inc for details.
 
 all:
-	$(MAKE) -C kernel
-	$(MAKE) -C command/msxdos
-	$(MAKE) -C tools
+	$(MAKE) -C kernel NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS)
+	$(MAKE) -C command/msxdos NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS)
+	$(MAKE) -C tools NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS)
 	$(MAKE) -C tools/C
 
 .PHONY: clean

--- a/source/command/msxdos/Makefile
+++ b/source/command/msxdos/Makefile
@@ -14,15 +14,9 @@ endif
 
 export LK80_ARGS=--no-show-banner --verbosity 0 --output-file-case lower --output-format bin
 
-# Optional: replace undocumented Z80 opcodes (the ones operating on
-# ixh/ixl/iyh/iyl) with documented equivalents, for compatibility with
-# Z180-based MSX machines. Set NO_UNDOC_CPU_INSTRUCTIONS=1 on the make
-# command line. See sdk/asm/macros/undoc.inc for details.
-ifeq ($(strip $(NO_UNDOC_CPU_INSTRUCTIONS)),)
-UNDOC_DEFINE=
-else
-UNDOC_DEFINE=NO_UNDOC_CPU_INSTRUCTIONS
-endif
+# NEXTOR.SYS contains no undocumented Z80 instructions, so the
+# NO_UNDOC_CPU_INSTRUCTIONS build flag (see sdk/asm/macros/undoc.inc)
+# has no effect here and is intentionally not plumbed through.
 
 define copy_to_bin
 	cp $(1) ../../../bin/tools/$(2)
@@ -30,12 +24,12 @@ endef
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
-	@$(N80) $(1) $(2) $(if $(UNDOC_DEFINE),--define-symbols $(UNDOC_DEFINE))
+	@$(N80) $(1) $(2)
 endef
 
 define assemble_as
 	@printf "\n\033[0;36mAssembling %s as %s\033[0m\n\n" $(1) $(2)
-	@$(N80) $(1) $(2) $(3) $(if $(UNDOC_DEFINE),--define-symbols $(UNDOC_DEFINE))
+	@$(N80) $(1) $(2) $(3)
 endef
 
 nextor-sys: NEXTOR.SYS NEXTORK.SYS

--- a/source/command/msxdos/Makefile
+++ b/source/command/msxdos/Makefile
@@ -14,18 +14,28 @@ endif
 
 export LK80_ARGS=--no-show-banner --verbosity 0 --output-file-case lower --output-format bin
 
+# Optional: replace undocumented Z80 opcodes (the ones operating on
+# ixh/ixl/iyh/iyl) with documented equivalents, for compatibility with
+# Z180-based MSX machines. Set NO_UNDOC_CPU_INSTRUCTIONS=1 on the make
+# command line. See sdk/asm/macros/undoc.inc for details.
+ifeq ($(strip $(NO_UNDOC_CPU_INSTRUCTIONS)),)
+UNDOC_DEFINE=
+else
+UNDOC_DEFINE=NO_UNDOC_CPU_INSTRUCTIONS
+endif
+
 define copy_to_bin
 	cp $(1) ../../../bin/tools/$(2)
 endef
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
-	@$(N80) $(1) $(2)
+	@$(N80) $(1) $(2) $(if $(UNDOC_DEFINE),--define-symbols $(UNDOC_DEFINE))
 endef
 
 define assemble_as
 	@printf "\n\033[0;36mAssembling %s as %s\033[0m\n\n" $(1) $(2)
-	@$(N80) $(1) $(2) $(3)
+	@$(N80) $(1) $(2) $(3) $(if $(UNDOC_DEFINE),--define-symbols $(UNDOC_DEFINE))
 endef
 
 nextor-sys: NEXTOR.SYS NEXTORK.SYS

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -35,11 +35,22 @@ endif
 # Optional: replace undocumented Z80 opcodes (the ones operating on ixh/ixl/
 # iyh/iyl) with documented equivalents, for compatibility with Z180-based
 # MSX machines. Set NO_UNDOC_CPU_INSTRUCTIONS=1 on the make command line.
+#
+# A mode-specific stamp file is touched whenever the flag changes, and is
+# listed as a prerequisite of every assembled target. That forces full
+# reassembly when switching between undoc and undoc-free builds so existing
+# .rel/.bin/.drv outputs from the previous mode are not silently reused.
 ifeq ($(strip $(NO_UNDOC_CPU_INSTRUCTIONS)),)
 UNDOC_DEFINE=
+UNDOC_MODE_STAMP=.undoc-mode-default
 else
 UNDOC_DEFINE=NO_UNDOC_CPU_INSTRUCTIONS
+UNDOC_MODE_STAMP=.undoc-mode-no-undoc
 endif
+
+$(UNDOC_MODE_STAMP):
+	@rm -f .undoc-mode-*
+	@touch $@
 
 define SymToEqus
     $(eval REGEX:=([0-9A-F]{4}) ($(3)))
@@ -112,6 +123,7 @@ drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/SunriseIDE/sunride.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/SunriseIDE/sunride.asm
 
 	$(call assemble,drivers/SunriseIDE/sunride.asm,--build-type abs --output-file-extension bin --define-symbols BAD_POPS)
@@ -130,6 +142,7 @@ drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/SunriseIDE/sunride.masteronly.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/SunriseIDE/sunride.asm
 
 	$(call assemble_as,drivers/SunriseIDE/sunride.asm,$$/sunride.masteronly.bin,--build-type abs --output-file-extension bin --define-symbols MASTER_ONLY,BAD_POPS)
@@ -150,6 +163,7 @@ drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.blueMSX.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/SunriseIDE/driver.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/SunriseIDE/driver.mac
 
 	$(call assemble,drivers/SunriseIDE/driver.mac,--build-type abs --output-file-extension bin)
@@ -170,6 +184,7 @@ drivers/SunriseIDE/Nextor-$(VERSION).SunriseIDE.MasterOnly.blueMSX.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/SunriseIDE/drvmonly.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/SunriseIDE/driver.mac
 
 	$(call assemble_as,drivers/SunriseIDE/driver.mac,$$/drvmonly.bin,--build-type abs  --output-file-extension bin --define-symbols MASTER_ONLY)
@@ -178,6 +193,7 @@ drivers/SunriseIDE/drvmonly.bin: \
 ### Sunrise IDE, common rules
 
 drivers/SunriseIDE/chgbnk.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/SunriseIDE/chgbnk.mac
 
 	$(call assemble,drivers/SunriseIDE/chgbnk.mac,--build-type abs --output-file-extension bin)
@@ -198,11 +214,13 @@ drivers/StandaloneASCII8/Nextor-$(VERSION).StandaloneASCII8.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/StandaloneASCII8/driver.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/StandaloneASCII8/driver.mac
 
 	$(call assemble,drivers/StandaloneASCII8/driver.mac,--build-type abs --output-file-extension bin)
 
 drivers/StandaloneASCII8/chgbnk.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/StandaloneASCII8/chgbnk.mac
 
 	$(call assemble,drivers/StandaloneASCII8/chgbnk.mac,--build-type abs --output-file-extension bin)
@@ -223,6 +241,7 @@ drivers/StandaloneASCII16/Nextor-$(VERSION).StandaloneASCII16.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/StandaloneASCII16/chgbnk.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/StandaloneASCII16/chgbnk.mac
 
 	$(call assemble,drivers/StandaloneASCII16/chgbnk.mac,--build-type abs --output-file-extension bin)
@@ -237,18 +256,21 @@ mfrsd: \
 	drivers/MegaFlashRomSD/Nextor-$(VERSION).MegaFlashSDSCC.2-slots.Recovery.ROM \
 
 drivers/MegaFlashRomSD/mfrsd-1slot.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/MegaFlashRomSD/mfrsd.asm \
 	drivers/MegaFlashRomSD/romdisk.asm
 
 	$(call assemble_as,drivers/MegaFlashRomSD/mfrsd.asm,$$/mfrsd-1slot.bin,--build-type abs --output-file-extension bin --define-symbols NUM_SLOTS=1)
 
 drivers/MegaFlashRomSD/mfrsd-2slots.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/MegaFlashRomSD/mfrsd.asm \
 	drivers/MegaFlashRomSD/romdisk.asm
 
 	$(call assemble_as,drivers/MegaFlashRomSD/mfrsd.asm,$$/mfrsd-2slots.bin,--build-type abs --output-file-extension bin --define-symbols NUM_SLOTS=2)
 
 drivers/MegaFlashRomSD/recovery_header.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/MegaFlashRomSD/recovery_header.asm
 
 	$(call assemble,drivers/MegaFlashRomSD/recovery_header.asm,--build-type abs --output-file-extension bin)
@@ -295,6 +317,7 @@ drivers/MegaFlashRomSD/Nextor-$(VERSION).MegaFlashSDSCC.2-slots.Recovery.ROM: \
 flashjacks: drivers/Flashjacks/Nextor-$(VERSION).Flashjacks.ROM
 
 drivers/Flashjacks/flashjacks.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/Flashjacks/flashjacks.asm
 
 	$(call assemble,drivers/Flashjacks/flashjacks.asm,--build-type abs --output-file-extension bin)
@@ -335,11 +358,13 @@ drivers/TurboRFDD/Nextor-$(VERSION).TurboRFDD.ROM: \
 	$(call copy_to_bin,$@)
 
 drivers/TurboRFDD/driver.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/TurboRFDD/driver.mac
 
 	$(call assemble,drivers/TurboRFDD/driver.mac,--build-type abs --output-file-extension bin)
 
 drivers/TurboRFDD/chgbnk.bin: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/TurboRFDD/chgbnk.mac
 
 	$(call assemble,drivers/TurboRFDD/chgbnk.mac,--build-type abs --output-file-extension bin)
@@ -350,6 +375,7 @@ drivers/TurboRFDD/chgbnk.bin: \
 dsk-tr-ram: drivers/TurboRFDD/turbofdd.drv
 
 drivers/TurboRFDD/turbofdd.drv: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/TurboRFDD/driver.mac
 
 	$(call assemble_as,drivers/TurboRFDD/driver.mac,$$/driver.ram.drv,--build-type abs --output-file-extension drv --define-symbols RAM_DRIVER)
@@ -363,6 +389,7 @@ drivers/TurboRFDD/turbofdd.drv: \
 ramdisk: drivers/RAMDisk/ramdisk.drv
 
 drivers/RAMDisk/ramdisk.drv: \
+	$(UNDOC_MODE_STAMP) \
 	drivers/RAMDisk/driver.mac
 
 	$(call assemble,drivers/RAMDisk/driver.mac,--build-type abs --output-file-extension drv)
@@ -435,6 +462,7 @@ lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(s
 
 .SECONDEXPANSION:
 $(filter-out $(SDK_COMRELS),$(COMRELS)) $(B0RELS) $(B1RELS) $(B2RELS) $(B3RELS) $(B4RELS) partit.rel $(B5RELS) $(B6RELS) print_call_help.rel drv.rel rel.rel: \
+	$(UNDOC_MODE_STAMP) \
 	macros.inc \
 	const.inc \
 	condasm.inc \
@@ -443,13 +471,13 @@ $(filter-out $(SDK_COMRELS),$(COMRELS)) $(B0RELS) $(B1RELS) $(B2RELS) $(B3RELS) 
 	$(call assemble,$(patsubst %.rel,%.mac,$@),--define-symbols GENERATE_PUBLIC_SYMBOLS)
 
 
-dos_calls.rel: ../../sdk/asm/constants/dos_calls.inc
+dos_calls.rel: $(UNDOC_MODE_STAMP) ../../sdk/asm/constants/dos_calls.inc
 	$(call assemble_as,../../sdk/asm/constants/dos_calls.inc,dos_calls.rel,--define-symbols GENERATE_PUBLIC_SYMBOLS)
 
-dos_errors.rel: ../../sdk/asm/constants/dos_errors.inc
+dos_errors.rel: $(UNDOC_MODE_STAMP) ../../sdk/asm/constants/dos_errors.inc
 	$(call assemble_as,../../sdk/asm/constants/dos_errors.inc,dos_errors.rel,--define-symbols GENERATE_PUBLIC_SYMBOLS)
 
-dos_file_handles.rel: ../../sdk/asm/constants/dos_file_handles.inc
+dos_file_handles.rel: $(UNDOC_MODE_STAMP) ../../sdk/asm/constants/dos_file_handles.inc
 	$(call assemble_as,../../sdk/asm/constants/dos_file_handles.inc,dos_file_handles.rel,--define-symbols GENERATE_PUBLIC_SYMBOLS)
 
 
@@ -492,6 +520,7 @@ bank0/b0lab_b6.inc: \
 ###  Bank 1
 
 bank1/b1.rel: \
+	$(UNDOC_MODE_STAMP) \
 	bank1/b1.mac \
 	bank0/b0labels.inc
 
@@ -515,6 +544,7 @@ bank1/B1.BIN: \
 ###  Bank 2
 
 bank2/b2.rel: \
+	$(UNDOC_MODE_STAMP) \
 	bank2/b2.mac \
 	bank0/b0labels.inc
 
@@ -544,6 +574,7 @@ bank2/b2labels.inc: \
 ###  Bank 3
 
 bank3/b3.rel: \
+	$(UNDOC_MODE_STAMP) \
 	bank3/b3.mac \
 	bank0/b0lab_b3.inc
 
@@ -567,6 +598,7 @@ bank3/B3.BIN: \
 ###  Bank 4
 
 bank4/b4.rel: \
+	$(UNDOC_MODE_STAMP) \
 	bank.inc \
 	bank4/b4.mac \
 	bank2/b2labels.inc
@@ -574,6 +606,7 @@ bank4/b4.rel: \
 	$(call assemble,bank4/b4.mac,--define-symbols GENERATE_PUBLIC_SYMBOLS)
 
 bank4/partit.rel: \
+	$(UNDOC_MODE_STAMP) \
 	bank4/partit.mac \
 	bank0/b0labels.inc
 
@@ -667,3 +700,4 @@ clean:
 	rm -f nextor_base.dat
 	rm -f bank0/b0lab*.inc
 	rm -f bank2/b2labels.inc
+	rm -f .undoc-mode-*

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -32,6 +32,15 @@ ifeq ($(strip $(MKNEXROM)),)
 MKNEXROM=mknexrom
 endif
 
+# Optional: replace undocumented Z80 opcodes (the ones operating on ixh/ixl/
+# iyh/iyl) with documented equivalents, for compatibility with Z180-based
+# MSX machines. Set NO_UNDOC_CPU_INSTRUCTIONS=1 on the make command line.
+ifeq ($(strip $(NO_UNDOC_CPU_INSTRUCTIONS)),)
+UNDOC_DEFINE=
+else
+UNDOC_DEFINE=NO_UNDOC_CPU_INSTRUCTIONS
+endif
+
 define SymToEqus
     $(eval REGEX:=([0-9A-F]{4}) ($(3)))
     cat $(1) | grep -Eo "$(REGEX)" | sed -r "s/$(REGEX)/\2 equ \1h\n\tpublic \2\n/g" > $(2)
@@ -47,12 +56,12 @@ endef
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
-	@$(N80) $(1) $$ $(2)
+	@$(N80) $(1) $$ $(2) $(if $(UNDOC_DEFINE),--define-symbols $(UNDOC_DEFINE))
 endef
 
 define assemble_as
 	@printf "\n\033[0;36mAssembling %s as %s\033[0m\n\n" $(1) $(2)
-	@$(N80) $(1) $(2) $(3)
+	@$(N80) $(1) $(2) $(3) $(if $(UNDOC_DEFINE),--define-symbols $(UNDOC_DEFINE))
 endef
 
 define print_linking
@@ -382,6 +391,19 @@ nextor_base.dat: \
 	bank5/B5.BIN \
 	bank5/fdisk.dat \
 	bank6/B6.BIN
+
+	@for f in bank0/B0.BIN bank3/B3.BIN; do \
+		sz=$$(stat -c '%s' $$f); \
+		if [ $$sz -gt 16384 ]; then \
+			echo "ERROR: $$f is $$sz bytes; max is 16384 (16 KB) per bank"; exit 1; \
+		fi; \
+	done
+	@for f in bank1/B1.BIN bank2/B2.BIN bank4/B4.BIN bank5/B5.BIN bank6/B6.BIN; do \
+		sz=$$(stat -c '%s' $$f); \
+		if [ $$sz -gt 16129 ]; then \
+			echo "ERROR: $$f is $$sz bytes; max is 16129 (16 KB minus the 4000h-40FEh doshead gap)"; exit 1; \
+		fi; \
+	done
 
 	cat bank0/B0.BIN 255.bytes bank1/B1.BIN 255.bytes bank2/B2.BIN bank3/B3.BIN 255.bytes bank4/B4.BIN 255.bytes bank5/B5.BIN 255.bytes bank6/B6.BIN > nextor_base.dat
 	dd conv=notrunc if=nextor_base.dat of=doshead.BIN bs=1 count=255

--- a/source/kernel/bank0/doshead.mac
+++ b/source/kernel/bank0/doshead.mac
@@ -81,7 +81,7 @@ $DOSVER::	defw	_$DOSVER##	;DOS version string.
 		call	CALBNK
 		exx
 		ex	af,af'
-		ld	a,iyl
+		ld_	a,iyl
 		or	a
 		jr	z,EXTB_RET
 		exx

--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -669,6 +669,61 @@ FREN:	CALLDOS	17h	;;Rename file (FCB)
 	ALIGN	4462h
 FOPEN:	CALLDOS	0Fh	;;Open file (FCB)
 ;
+;-----------------------------------------------------------------------------
+;
+TIMI_DOS2_DRV:
+;
+;   Call the interrupt routines of drivers attached to MSX-DOS 2 kernels.
+;   These are the ones that have an entry in HOOKSAV whose slot number matches
+;   the entry with the same index in DRVTBL##, thus representing a "my hook" entry
+;   (if the slot number is different then the HOOKSAV entry has been
+;   set by a driver attached to a MSX-DOS 1 kernel, and in this case
+;   it represents a "previous hook" entry and the driver itself will call it
+;   at the end of its own interrupt routine).
+;
+	ld	de,DRVTBL##
+	ld	hl,HOOKSAV
+	ld	b,MAXCARD
+scan_loop:
+	ld	a,(de)		;Get number of drives
+	and	a		; no drives?
+	ret	z		; yes, done
+
+	inc	de
+	ld	a,(de)		;Get slot address from DRVTBL##
+	inc	de
+	cp	(hl)		; same slot number in equivalent HOOKSAV entry?
+	jr	nz,next_cart	; no, HOOKSAV entry has been set by DOS 1 SETINT
+	ld	a,(hl)		; slot number
+	push	bc		; save count
+	push	de		;  DRVTBL## pointer
+	push	hl		;  HOOKSAV pointer
+	inc	hl
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+
+	;Set IYh = slot (the value CALSLT will use as the target slot).
+
+	ld	h,a
+	push	hl
+	pop	iy
+
+	push	de
+	pop	ix
+	call	CALSLT
+	pop	hl
+	pop	de
+	pop	bc
+next_cart:
+	inc	hl
+	inc	hl
+	inc	hl
+	djnz	scan_loop
+	ret
+;
+;-----------------------------------------------------------------------------
+;
 	ALIGN	456Fh
 FCLOSE:	CALLDOS	10h	;;Close file (FCB)
 ;
@@ -2149,54 +2204,9 @@ DOS2INT:
 	pop	af		;Restore VDP status.
 	jp	TIMI_SAVE##	;Jump to the previous interrupt routine.
 
+;
+;
 
-TIMI_DOS2_DRV:
-;
-;   Call the interrupt routines of drivers attached to MSX-DOS 2 kernels.
-;   These are the ones that have an entry in HOOKSAV whose slot number matches
-;   the entry with the same index in DRVTBL##, thus representing a "my hook" entry
-;   (if the slot number is different then the HOOKSAV entry has been
-;   set by a driver attached to a MSX-DOS 1 kernel, and in this case
-;   it represents a "previous hook" entry and the driver itself will call it
-;   at the end of its own interrupt routine).
-;
-	ld	de,DRVTBL##
-	ld	hl,HOOKSAV
-	ld	b,MAXCARD
-scan_loop:
-	ld	a,(de)		;Get number of drives
-	and	a		; no drives?
-	ret	z		; yes, done
-
-	inc	de
-	ld	a,(de)		;Get slot address from DRVTBL##
-	inc	de
-	cp	(hl)		; same slot number in equivalent HOOKSAV entry?
-	jr	nz,next_cart	; no, HOOKSAV entry has been set by DOS 1 SETINT
-	ld	a,(hl)		; slot number
-	push	bc		; save count
-	push	de		;  DRVTBL## pointer
-	push	hl		;  HOOKSAV pointer
-	inc	hl
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	iyh,a
-	push	de
-	pop	ix
-	call	CALSLT
-	pop	hl
-	pop	de
-	pop	bc
-next_cart:
-	inc	hl
-	inc	hl
-	inc	hl
-	djnz	scan_loop
-	ret
-;
-;
-;
 TIMI_NEXTOR_DRV:
 ;
 ;   Call the interrupt routine of all drivers attached to Nextor kernels.
@@ -2211,10 +2221,12 @@ TNEX_LOOP:
 	push	hl
 	push	bc
 	and	10001111b
-	ld	iyh,a
+	ld	h,a		;H = slot (also stand-in for iyh)
+	push	hl
+	pop	iy		;IYh = slot
 	ld	a,(MASTER_SLOT##)
-	cp	iyh
-	ld	a,iyh
+	cp	h
+	ld	a,h
 	ld	h,40h
 	ld	ix,DV_TIRQ##
 	call	call_drv

--- a/source/kernel/bank1/dosinit.mac
+++ b/source/kernel/bank1/dosinit.mac
@@ -1407,7 +1407,7 @@ _U_CALLRAM:
         ex      af,af
 ...	      < call	_GET_P1 >
         push    af
-        ld a,iyl
+        ld_ a,iyl
 ...	      < call	_PUT_P1 >
         ex      af,af
         call    CALSLT
@@ -1494,7 +1494,7 @@ _U_CALLRAM2:
         dec     ix
         dec     ix
         push    ix
-        ld iyl,e
+        ld_ iyl,e
 
         ld      a,d
         and     00111111b
@@ -1518,13 +1518,21 @@ _U_CALLRAM2:
         ld      bc,(MAP_TAB##)
         add     hl,bc
         ld      a,(hl)  ;A = Slot to call
-        ld iyh,a
+        ld_ iyh,a
 
         ex      af,af'
         exx
         inc     sp
         inc     sp
+
+        ;The NO_UNDOC variants of `ld_ iyl,e` and `ld_ iyh,a` above
+        ;expand by 5 bytes each, pushing the target out of jr range.
+
+        ifdef	NO_UNDOC_CPU_INSTRUCTIONS
+        jp      _U_CALLRAM
+        else
         jr      _U_CALLRAM
+        endif
 ;
 ;-----------------------------------------------------------------------------
 ;

--- a/source/kernel/bank1/mapinit.mac
+++ b/source/kernel/bank1/mapinit.mac
@@ -664,7 +664,7 @@ MAPBDO_FOUND:
 		ld	a,DV_BANK##
 		call	DH_CABNK##
 		ex	af,af'		;Save driver's AF
-		ld	a,iyl
+		ld_	a,iyl
 		or	a
 		jr	nz,MAPBIO2
 		ex	af,af'		;Restore driver's AF
@@ -676,7 +676,7 @@ MAPBIO2:
 MAPBDO_SK2:
 		call	EXB_NEX
 		ex	af,af'
-		ld	a,iyl
+		ld_	a,iyl
 		or	a
 		jr	nz,MAPBIO22
 		ex	af,af'
@@ -694,7 +694,7 @@ MAPBIO22:
 
 		call	EXB_RAM_DRV
 		ex	af,af'		;Save driver's AF
-		ld	a,iyl
+		ld_	a,iyl
 		or	a
 		jr	nz,MAPBIO3
 ;
@@ -712,7 +712,7 @@ MAPBIO3:
 		push	af
 		call	CHK_DEV
 		ex af,af'
-		ld	a,iyl
+		ld_	a,iyl
 		or	a
 		jr	z,MAPB_DONT_CALL_OLD
 
@@ -1091,7 +1091,7 @@ ERAMX_ENT:
 	pop	hl
 	ld	(KBUF),hl
 	;Check IYl (A is free since results already saved)
-	ld	a,iyl
+	ld_	a,iyl
 	bit	0,a
 	pop	bc
 	pop	hl

--- a/source/kernel/bank3/dos1ker.mac
+++ b/source/kernel/bank3/dos1ker.mac
@@ -21,6 +21,7 @@
 	INCLUDE ../../../sdk/asm/constants/msx_bios.inc
 	INCLUDE ../../../sdk/asm/constants/msx_workarea.inc
 	INCLUDE ../../../sdk/asm/constants/msx_basic.inc
+	INCLUDE ../../../sdk/asm/macros/undoc.inc
 
 PRINTL	macro	NAME,VALUE
 	if2
@@ -5979,7 +5980,7 @@ A6101:	call	A609A			; mark FAT buffer as invalid
 	;--- Get format choice via common bank 6 routine
 
 	ld	c,a		;C = device number
-	ld	a,iyh
+	ld_	a,iyh
 	ld	(BUF+100),a	;Save slot for bank 6 routine
 	ld	hl,FMT_PRINT_AND_CHOOSE##
 	set	7,h		;Bit 15 = call bank 6

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -182,14 +182,14 @@ DO_EXTPAR:
 	jp	nz,UNEX_PART
 
 	ld	a,(ix+POFF_PSTART)	;Save the start sector number of the outer extended partition
-	ld iyl,a			;(the one that includes all other extended partitions).
+	ld_ iyl,a			;(the one that includes all other extended partitions).
 	ld	a,(ix+POFF_PSTART+1)	;We need it to calculate the offsets of the inner
-	ld iyh,a			;extended partitions.
+	ld_ iyh,a			;extended partitions.
 	push	iy
 	ld	a,(ix+POFF_PSTART+2)
-	ld iyl,a
+	ld_ iyl,a
 	ld	a,(ix+POFF_PSTART+3)
-	ld iyh,a
+	ld_ iyh,a
 	push	iy
 
 	;=== Loop for extended partition search ===
@@ -332,7 +332,7 @@ DEV_READ:
 	jr	nz,DEV_READ_RAM
 ;
 	;--- ROM driver path
-	ld	iyh,c
+	ld_	iyh,c
 	ld	ix,DRIVER.READ_WRITE_ENTRY##
 	ld	(BK4_ADD##),ix
 	ld	ix,CALDRV##
@@ -640,7 +640,7 @@ AUTODRV_DRVLOOP:
 	;      A  = Relative drive for the driver
 
 	ld	c,a
-	ld a,iyl
+	ld_ a,iyl
 	ld	(ix+UD1_SLOT##),a		;Set slot number in table entry
 	ld	a,c
     ld  (ix+UD1_RELATIVE_DRIVE##),a    
@@ -718,7 +718,7 @@ AUTOD_UDFND:
 	;--- Check if it is assigned to a device based driver
 
 	ld	a,(ix+UD_SLOT##)
-	ld iyh,a
+	ld_ iyh,a
 
 	ld	c,a
 	ld	a,(KERNEX##)
@@ -913,7 +913,7 @@ AUTO_ASSIGN:
 	ld hl,DRIVER.DRIVER_QUERY_ENTRY##
 	ld	(BK4_ADD##),hl
 	ld a,(iy+UD_SLOT##)
-	ld iyh,a
+	ld_ iyh,a
 	ld a,DRIVER_QUERY.GET_MAX_DEVICE##
 	ld	ix,CALDRV##
 	call	CALSLT
@@ -991,7 +991,7 @@ AA_DLOOP:
 
 AA_GET_DEVINFO:
 	ld	a,(ix+AAD_DRIVER_SLOT)
-	ld iyh,a
+	ld_ iyh,a
 	ld	hl,DRIVER.DEVICE_QUERY_ENTRY##
 	ld	(BK4_ADD##),hl
 	ld	hl,($SECBUF##)
@@ -1572,8 +1572,8 @@ AA_WSEC:
 
 AA_RSEC:
     or a
-AA_DOSEC:    
-	ld iyh,c
+AA_DOSEC:
+	ld_ iyh,c
 	ld	hl,DRIVER.READ_WRITE_ENTRY##
 	ld	(BK4_ADD##),hl
 	ld	b,1
@@ -2655,7 +2655,7 @@ F_CDRVR_GO:
 	;--- ROM driver path
 
 	ld	(BK4_ADD##),de
-	ld iyh,c
+	ld_ iyh,c
 	ld	l,(ix)
 	ld	h,(ix+1)
 	push	hl
@@ -2738,8 +2738,8 @@ CDRVR_RAM:
 
 	ld	(BUF),de	;Save routine address to page-3 scratch
 
-	ld	iyh,c		;IY = slot:segment
-	ld	iyl,b
+	ld_	iyh,c		;IY = slot:segment
+	ld_	iyl,b
 
 	;Load input params from buffer (IX still = buffer ptr)
 
@@ -2885,10 +2885,10 @@ UNMAP_LOOP:
 	inc	hl
 	ld	h,(hl)
 	ld	l,a
-	cp iyl
+	cp_ iyl
 	jr	nz,UNMAP_OK1
 	ld	a,h
-	cp iyh
+	cp_ iyh
 	jr	z,UNMAP_NEXT2	;It is the unit not to be unassigned
 UNMAP_OK1:
 
@@ -3358,7 +3358,7 @@ MAPS_SEG_OK:
 	ld	(BK4_ADD##),hl
 	ld	a,(iy)
 	ld	c,(iy+2)
-	ld iyh,a
+	ld_ iyh,a
 	ld	hl,($SECBUF##)
 	ld	ix,CALDRV##
 	ld a,DEVICE_QUERY.GET_PARAMS##
@@ -3414,7 +3414,7 @@ MAPS_DONE_GP:
 	ld	(BK4_ADD##),hl
 	ld	a,(iy)
 	ld	c,(iy+2)
-	ld iyh,a
+	ld_ iyh,a
 	ld a,DEVICE_QUERY.GET_STATUS##
 	ld	ix,CALDRV##
 	call	CALSLT
@@ -4381,7 +4381,7 @@ MAPDOS1_CHK_NEXT:
 	ld	a,(iy)
 	ld	c,(iy+2)
 	ld	b,(iy+3)
-	ld iyh,a
+	ld_ iyh,a
 	ld	hl,($SECBUF##)
 	ld	ix,CALDRV##
 	ld a,DEVICE_QUERY.GET_PARAMS##
@@ -7560,10 +7560,10 @@ DRVRO_I2:
 
 	ld	a,(BUF)
 	ld	b,a		;B = slot
-	ld	iyh,a		;slot for CALL_MAP
+	ld_	iyh,a		;slot for CALL_MAP
 	ld	a,(BUF+1)
 	ld	c,a		;C = segment
-	ld	iyl,a		;segment for CALL_MAP
+	ld_	iyl,a		;segment for CALL_MAP
 	ld	ix,DRIVER.DRIVER_QUERY_ENTRY##
 	ld	a,DRIVER_QUERY.INIT_RAM##
 
@@ -7644,9 +7644,9 @@ DRVRO_S3:
 	call	DRVRO_TPA_ON	;TPA in pages 0/2 for print routine
 
 	ld	a,(BUF)
-	ld	iyh,a
+	ld_	iyh,a
 	ld	a,(BUF+1)
-	ld	iyl,a
+	ld_	iyl,a
 	ld	ix,DRIVER.DRIVER_QUERY_ENTRY##
 	ld	a,DRIVER_QUERY.SHUTDOWN_RAM##
 	call	CALL_MAP##

--- a/source/kernel/bank6/format.mac
+++ b/source/kernel/bank6/format.mac
@@ -287,7 +287,7 @@ fformat_dos_choice:
 	;--- MSX-DOS: call CHOICE (4019h) in driver ROM via CALSLT
 
 	ld	a,(BUF+100)
-	ld	iyh,a		;IYh = driver slot
+	ld_	iyh,a		;IYh = driver slot
 	ld	a,(BUF+102)	;A = relative drive number within driver
 	ld	ix,4019h	;CHOICE entry point
 	call	001Ch		;CALSLT -> HL = ROM choice string addr
@@ -400,7 +400,7 @@ fformat_dos_do_format:
 	push	de
 	pop	bc		;BC = buffer size
 	ld	a,(BUF+100)
-	ld	iyh,a		;IYh = driver slot
+	ld_	iyh,a		;IYh = driver slot
 	ld	a,(BUF+102)
 	ld	d,a		;D = relative drive (0-based)
 	ld	a,(BUF+103)	;A = choice (1-9)
@@ -541,7 +541,7 @@ fpc_msxdos:
 
 	push	hl		;Save buffer destination
 	ld	a,(BUF+100)
-	ld	iyh,a
+	ld_	iyh,a
 	ld	a,c		;A = drive number within driver
 	ld	ix,4019h	;CHOICE entry point
 	call	001Ch		;CALSLT -> HL = ROM choice string
@@ -722,7 +722,7 @@ CDQ_ROM:
 	ld	hl,DRIVER.DEVICE_QUERY_ENTRY##
 	ld	(BK4_ADD##),hl	;Store routine address for CALDRV
 	ld	a,(BUF+100)
-	ld	iyh,a		;IYh = driver slot
+	ld_	iyh,a		;IYh = driver slot
 	ld	ix,CALDRV##	;IX = CALDRV entry (doshead)
 	pop	af		;A = query number
 	pop	hl		;HL = buffer address
@@ -730,9 +730,9 @@ CDQ_ROM:
 
 CDQ_RAM:
 	;--- RAM driver: call DEVICE_QUERY via CALL_MAP
-	ld	iyl,a		;IYl = segment (A still has BUF+106 value)
+	ld_	iyl,a		;IYl = segment (A still has BUF+106 value)
 	ld	a,(BUF+100)
-	ld	iyh,a		;IYh = slot
+	ld_	iyh,a		;IYh = slot
 	ld	ix,DRIVER.DEVICE_QUERY_ENTRY##
 	pop	af		;A = query number
 	jp	CALL_MAP##
@@ -783,7 +783,7 @@ dcb_size_ok:
 	ld	a,(iy+UD_SLOT##)
 	ld	(BUF+100),a	;Save slot for RDSLT
 	ld	c,(iy+UD_RELATIVE_UNIT_NUMBER##) ;Save relative drive number
-	ld	iyh,a		;IYh = driver slot for CALSLT
+	ld_	iyh,a		;IYh = driver slot for CALSLT
 	ld	a,c		;A = relative drive number for CHOICE
 	ld	ix,4019h	;CHOICE entry point
 	call	001Ch		;CALSLT -> HL = ROM choice string addr
@@ -982,7 +982,7 @@ MAP_USER_BUF:
 	ld	(BUF+104),a	;Save original page 2 segment
 
 	;Determine which page the buffer is in from top 2 bits of IXh
-	ld	a,ixh
+	ld_	a,ixh
 	and	11000000b
 	cp	0C0h
 	jr	z,mub_page3	;Page 3: no remapping
@@ -1010,10 +1010,10 @@ MAP_USER_BUF:
 	pop	hl
 
 	;Convert IX to page 2 range: clear top 2 bits, set bit 7
-	ld	a,ixh
+	ld_	a,ixh
 	and	00111111b
 	or	10000000b
-	ld	ixh,a
+	ld_	ixh,a
 	or	a		;Clear carry (remapping done)
 	ret
 
@@ -1047,16 +1047,16 @@ RESTORE_PAGE2:
 ;    Corrupts: A (only if boundary crossed)
 ;
 CHECK_IX_BOUNDARY:
-	ld	a,ixh
+	ld_	a,ixh
 	cp	0C0h
 	ret	nz		;High byte not C0h: not at boundary
-	ld	a,ixl
+	ld_	a,ixl
 	or	a
 	ret	nz		;Low byte not 00h: not at boundary
 	;IX = C000h exactly: crossed from BFFFh to C000h
 	ld	a,(BUF+105)
 	call	PUT_P2##
-	ld	ixh,80h		;Wrap to start of page 2 (IXl already 0)
+	ld_	ixh,80h		;Wrap to start of page 2 (IXl already 0)
 	ret
 
 ;-----------------------------------------------------------------------------

--- a/source/kernel/bank6/idrvauto.mac
+++ b/source/kernel/bank6/idrvauto.mac
@@ -827,9 +827,9 @@ UDRV_OK_MSG:
 	;--- Step 1: Get max device number
 
 	ld	a,(IDRV_SLOT)
-	ld	iyh,a
+	ld_	iyh,a
 	ld	a,(IDRV_SEG)
-	ld	iyl,a
+	ld_	iyl,a
 	ld	ix,DRIVER.DRIVER_QUERY_ENTRY##
 	ld	a,DRIVER_QUERY.GET_MAX_DEVICE##
 	call	CALL_MAP##
@@ -850,9 +850,9 @@ IAM_DEVLOOP:
 	push	bc
 
 	ld	a,(IDRV_SLOT)
-	ld	iyh,a
+	ld_	iyh,a
 	ld	a,(IDRV_SEG)
-	ld	iyl,a
+	ld_	iyl,a
 	ld	ix,DRIVER.DEVICE_QUERY_ENTRY##
 	ld	a,DEVICE_QUERY.GET_PARAMS##
 	ld	hl,($SECBUF##)
@@ -972,9 +972,9 @@ IAM_UTFOUND:
 	ld	c,a		;C = device number for GET_STRING query
 
 	ld	a,(IDRV_SLOT)
-	ld	iyh,a
+	ld_	iyh,a
 	ld	a,(IDRV_SEG)
-	ld	iyl,a
+	ld_	iyl,a
 	ld	ix,DRIVER.DEVICE_QUERY_ENTRY##
 	ld	a,DEVICE_QUERY.GET_STRING##
 	ld	b,4		;B = string type 4 (device name)

--- a/source/kernel/drivers/Flashjacks/flashjacks.asm
+++ b/source/kernel/drivers/Flashjacks/flashjacks.asm
@@ -4,7 +4,9 @@
 	; Based on version 0.1 by Konamiman and 0.15 by Piter Punk
 
 	;output	"sunride_aquijacks.bin"
-	
+
+	INCLUDE ../../../../sdk/asm/macros/undoc.inc
+
 	org		4000h
 
 	ds		256, 0FFh		; 256 dummy bytes
@@ -1703,9 +1705,9 @@ _TURBO3:
 
 _CIEL1:	ld	b,3
 _CIEL2: ld	a,(hl)
-	ld	ixh,a
+	ld_	ixh,a
 	ld	a,(de)
-	cp	ixh
+	cp_	ixh
 	jr	nz,NOTCIEL
 	inc	hl
 	inc	de

--- a/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
+++ b/source/kernel/drivers/MegaFlashRomSD/mfrsd.asm
@@ -9,9 +9,11 @@
 
 	.RELAB
 
+	INCLUDE ../../../../sdk/asm/macros/undoc.inc
+
 ;---------------------------------------------------------------------------
 ; MACROS
-;---------------------------------------------------------------------------				
+;---------------------------------------------------------------------------
 
 ADD_HL_A macro
 		add	a, l	; 4
@@ -766,7 +768,7 @@ NEXTOR2_DEV_INFO:
 		ld	b,15 + 2
 		call	SkipBytes
 		call	GetManufacName
-		ld	b,iyh
+		ld_	b,iyh
 		call OUTPUT_STRING		; Copy manufacturer name to buffer
 		pop	bc	;B = ID
 		or a
@@ -775,7 +777,7 @@ NEXTOR2_DEV_INFO:
 		; Add [id] to the manufacturer name
 		; if the buffer was at least 20 bytes long
 
-		ld a,iyh
+		ld_ a,iyh
 		cp 20
 		jr c,.DEV_END_NOERR
 		ld a," "
@@ -800,12 +802,12 @@ NEXTOR2_DEV_INFO:
 		
 		; 2: Device name string
 
-		ld a,iyh
+		ld_ a,iyh
 		cp 6+1	; Enough space for the entire string (4 bytes + zero byte)?
 		ld c,5  ; C = Length to copy
 		ld a,RESULT_OK  ; A = Error to return
 		jr nc,.DEV_INFO2_OKLEN
-		ld c,iyh
+		ld_ c,iyh
 		dec c	;Copy one byte less to make size for the zero byte
 		ld a,RESULT_TRUNCATED_STRING
 .DEV_INFO2_OKLEN:
@@ -829,7 +831,7 @@ NEXTOR2_DEV_INFO:
 		
 		; 3: Serial number string
 
-		ld a,iyh
+		ld_ a,iyh
 		cp 5	;Enough buffer (4 hex bytes + zero)?
 		ld a,RESULT_NOT_IMPLEMENTED
 		jp c,SD_OFF_EI

--- a/source/kernel/drivers/SunriseIDE/sunride.asm
+++ b/source/kernel/drivers/SunriseIDE/sunride.asm
@@ -13,6 +13,8 @@ DRV_START:
 
 	.RELAB
 
+	INCLUDE ../../../../sdk/asm/macros/undoc.inc
+
 TESTADD	equ	0F3F5h
 
 ;A few Panasonic FS machines uses the area around C000-C400 at boot time,
@@ -981,8 +983,7 @@ DEV_RW2:
 	ld	b,0
 	ret	
 DEV_RW_NO0SEC:
- 	ld iyl,e
- 	ld iyh,d
+ 	ld_ iy,de
 	ld	a,(iy+3)
 	and	11110000b
 	jp	nz,DEV_RW_NOSEC	;Only 28 bit sector numbers supported
@@ -1020,7 +1021,7 @@ DEV_ATA_RD:
 
 	call	CHK_RW_FAULT
 	ret	c
-	ld	iyl,b		; iyl=number of blocks
+	ld_	iyl,b		; iyl=number of blocks
 	ex	de,hl		; de=destination address
 
 	ld	bc,512		; block size  ***Hardcoded. Ignores (BLKLEN)
@@ -1037,7 +1038,7 @@ DEV_ATA_WR:
 	ld	a,ATACMD.PWRSECTRT	; PIO write sector with retry
 	call	PIO_CMD
 	jp	c,DEV_RW_ERR
-	ld	iyl,b		; iyl=number of blocks
+	ld_	iyl,b		; iyl=number of blocks
 
 	ld	bc,512		; block size  ***Hardcoded. Ignores (BLKLEN)
 	call	WRITE_DATA
@@ -1055,8 +1056,7 @@ DEV_ATAPI_RW:
 	push	de
 	ld	e,(ix+DEVINFO.pBASEWRK)		; hl=pointer to WorkArea
 	ld	d,(ix+DEVINFO.pBASEWRK+1)
-	ld iyl,e
- 	ld iyh,d				; iy=WRKAREA pointer
+	ld_ iy,de				; iy=WRKAREA pointer
 	pop	de
 
 	; Set the block size
@@ -1103,7 +1103,7 @@ DEV_ATAPI_RD:
 	push	bc
 	push 	hl
 	push	iy
-	ld	iyl,1			; 1 block
+	ld_	iyl,1			; 1 block
 	ld	hl,WRKAREA.PCTBUFF
 	ld	bc,PCTRW10._SIZE		; block size=10 bytes
 	call	WRITE_DATA		; Send the packet to the device
@@ -1135,7 +1135,7 @@ DEV_ATAPI_RD:
 	ld	e,(ix+DEVINFO.SECTSIZE)
 	ld	d,(ix+DEVINFO.SECTSIZE+1)
 
-.init2:	
+.init2:
 	ld	c,a		; c=number of 512-byte blocks per sector
 
 	push	bc
@@ -1146,13 +1146,13 @@ DEV_ATAPI_RD:
 	ex	de,hl		; de=destination address
 .loopsector:
 	push	bc
-	ld	iyl,c		; get the number of blocks per sector
+	ld_	iyl,c		; get the number of blocks per sector
 .loopblock:
 	call	WAIT_DRQ
 	jr	c,.rderr
 	ld	hl,IDE_DATA
 	call	RUN_HLPR
-	dec	iyl
+	dec_	iyl
 	jr	nz,.loopblock
 	pop	bc
 	djnz	.loopsector
@@ -1174,7 +1174,7 @@ DEV_ATAPI_WR:
 	push	bc
 	push	hl
 	push	iy
-	ld	iyl,1			; 1 block
+	ld_	iyl,1			; 1 block
 	ld	hl,WRKAREA.PCTBUFF
 	ld	bc,PCTRW10._SIZE		; block size=10 bytes
 	call	WRITE_DATA		; Send the packet to the device
@@ -1206,7 +1206,7 @@ DEV_ATAPI_WR:
 	ld	e,(ix+DEVINFO.SECTSIZE)
 	ld	d,(ix+DEVINFO.SECTSIZE+1)
 
-.init2:	
+.init2:
 	ld	c,a		; c=number of 512-byte blocks per sector
 
 	push	bc
@@ -1216,7 +1216,7 @@ DEV_ATAPI_WR:
 	pop	bc
 .loopsector:
 	push	bc
-	ld	iyl,c		; get the number of blocks per sector
+	ld_	iyl,c		; get the number of blocks per sector
 .loopblock:
 	call	WAIT_DRQ
 	jr	c,.rderr
@@ -1224,7 +1224,7 @@ DEV_ATAPI_WR:
 	call	RUN_HLPR
 	call	CHK_RW_FAULT
 	jr	c,.rderr
-	dec	iyl
+	dec_	iyl
 	jp	nz,.loopblock
 	pop	bc
 	djnz	.loopsector
@@ -1776,7 +1776,7 @@ LUN_NFO_ATAPI:
 	push	hl		; Source=PCTBUF
 	ld	bc,12		; 12 byte packet
 	push	iy
-	ld	iyl,1
+	ld_	iyl,1
 	call	WRITE_DATA	; Send the packet to the device
 	pop	iy
 	jr	nc,.rdmediapropr	; No error? Then read media proprieties
@@ -1794,7 +1794,7 @@ LUN_NFO_ATAPI:
 	pop	de		; Destination=PCTBUFF
 	ld	bc,8		; 8 byte response
 	push	iy
-	ld	iyl,1
+	ld_	iyl,1
 	call	READ_DATA
 	pop	iy
 	jr	c,LUN_INFO_ERROR
@@ -2391,13 +2391,13 @@ READ_DATA:
 	ret	c
 	ld	hl,IDE_DATA
 	call	RUN_HLPR
-	dec	iyl
+	dec_	iyl
 	jp	nz,.loop
 	ret
 
 
 ;-----------------------------------------------------------------------------
-; Subroutine to write blocks of arbitrary size on the IDE 
+; Subroutine to write blocks of arbitrary size on the IDE
 ; Input: HL =Data source
 ;        BC =block size
 ;        IYL=Number of blocks
@@ -2410,7 +2410,7 @@ WRITE_DATA:
 	call	RUN_HLPR
 	call	CHK_RW_FAULT
 	ret	c
-	dec	iyl
+	dec_	iyl
 	jp	nz,.loop
 	ret
 

--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -776,8 +776,8 @@ GET_KERNEX_DOS1_PNT:
 	jr	nz,IS_NOT_DVB
 
 	ld	iy,(KERNEX_DOS1##)
-	ld a,iyh
-	or iyl
+	ld_ a,iyh
+	or_ iyl
 	jr	z,IS_NOT_DVB
 
 	ld	a,(iy)

--- a/source/kernel/macros.inc
+++ b/source/kernel/macros.inc
@@ -9,6 +9,7 @@ TRUE    equ     NOT FALSE
 
 
 	include ../../sdk/asm/macros/const.inc
+	include ../../sdk/asm/macros/undoc.inc
 ;
 ;
 ;

--- a/source/tools/MAPDRV.MAC
+++ b/source/tools/MAPDRV.MAC
@@ -1,5 +1,4 @@
 	.z80
-	;include	MACROS.INC
 
 FIB	equ	3000h
 
@@ -11,13 +10,14 @@ PT_EXT_LBA: equ 15
 
       ; -------------------------------------------------------------------------------
 	db	13
-	db	"MAPDRV v1.1 - map a drive to a driver, device, LUN and partition,",13,10
+	db	"MAPDRV v1.2 - map a drive to a driver, device, LUN and partition,",13,10
 	db      "         or mount a file on a drive"
 	db	13,10
 	db	"Usage:",13,10
 	db	13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [<slot>[-<subslot>]|0]]",13,10
-	db      "MAPDRV <drive>: [/]<filename> [/ro]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [<slot>[-<subslot>][:<segment>]]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [0]",13,10
+	db  "MAPDRV <drive>: [/]<filename> [/ro]",13,10
 	db	13,10
 	db	"Maps the drive to the specified partition of the specified device",13,10
 	db	"of the driver in the specified slot (must be a device-based driver).",13,10
@@ -33,6 +33,7 @@ PT_EXT_LBA: equ 15
 	db	13,10
 	db	"<slot> and <subslot> must be a number from 0 to 3. If 0 is specified instead,",13,10
 	db	"the primary disk controller slot is assumed.",13,10
+	db  "<segment> must be a number from 0 to 255, only used for RAM drivers.",13,10
 	db	13,10
 	db	"If device information is provided but slot is omitted, the drive is mapped to",13,10
 	db	"the specified partition of the specified device in the driver already",13,10
@@ -56,8 +57,9 @@ USAGE_S:
 	db	"MAPDRV - map a drive to a driver, device, LUN and partition",13,10
 	db  "         or mount a file on a drive",13,10
 	db	13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [<slot>[-<subslot>]|0]]",13,10
-	db      "MAPDRV <drive>: [/]<filename> [/ro]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [<slot>[-<subslot>][:<segment>]]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [0]",13,10
+	db  "MAPDRV <drive>: [/]<filename> [/ro]",13,10
 	db	13,10
 	db	"TYPE MAPDRV.COM for more details.",13,10
 	db	0
@@ -115,10 +117,7 @@ NO_LOCK:
 
 	;* Partition number, or "d", "u", or file name
 
-	ld	de,BUF
-	ld a,iyl
-	inc	iy
-	call	EXTPAR##
+	call	GET_NEXT_PARAM
 	ld	b,.NOPAR##
 	ld	c,_TERM##
 	jp	c,5
@@ -150,10 +149,7 @@ IS_PART:
 
 	;* Device
 
-	ld	de,BUF
-	ld a,iyl
-	inc	iy
-	call	EXTPAR##
+	call	GET_NEXT_PARAM
 	jp	c,DO_MAP
 
 	ld hl,BUF
@@ -163,10 +159,7 @@ IS_PART:
 
 	;* Slot, subslot, segment
 
-	ld	de,BUF
-	ld a,iyl
-	inc	iy
-	call	EXTPAR##
+	call	GET_NEXT_PARAM
 	jp	c,DO_MAP
 
 	ld	hl,BUF
@@ -405,6 +398,20 @@ NOPARM_TERM:
 	ld	b,.NOPAR##
 	ld	c,_TERM##
 	jp	5
+
+
+	;Get the next command-line parameter.
+	;Input:   IY = parameter index in IYl
+	;Output:  same as EXTPAR##, with IY advanced past this parameter
+	;Corrupts: HL (in addition to whatever EXTPAR## corrupts)
+
+GET_NEXT_PARAM:
+	ld	de,BUF
+	push	iy
+	pop	hl
+	ld	a,l
+	inc	iy
+	jp	EXTPAR##
 
 
 CHKNEX21:

--- a/source/tools/Makefile
+++ b/source/tools/Makefile
@@ -7,7 +7,7 @@ ifeq ($(strip $(N80)),)
 N80=N80
 endif
 
-export N80_ARGS=--no-string-escapes --no-show-banner --build-type rel --verbosity 3 --output-file-case upper --include-directory ../kernel
+export N80_ARGS=--no-string-escapes --no-show-banner --build-type rel --verbosity 0 --output-file-case upper --include-directory ../kernel
 
 ifeq ($(strip $(LK80)),)
 LK80=LK80


### PR DESCRIPTION
If `NO_UNDOC_CPU_INSTRUCTIONS=1` is specified when running `make`, the build will exclude support for undocumented Z80 opcodes. This will make the resulting binaries compatible with Z180 CPUs. See `sdk/asm/macros/undoc.inc` for a reference of the implemented replacement macros.

Inspired by [#133](https://github.com/Konamiman/Nextor/pull/133) by [lfantoniosi](https://github.com/lfantoniosi).
