### PR TITLE
Miscellaneous fixes

### DIFF
--- a/source/kernel/bank0/bdos.mac
+++ b/source/kernel/bank0/bdos.mac
@@ -37,16 +37,23 @@ DB_INIT::
 ;
 ;    Template for the KABJ/KDERJ hooks that get copied to page 3 RAM
 ; (KABJ_CODE and KDERJ_CODE) during initialization. These hooks switch
-; to bank 0 via CHGBNK before jumping to KABR/KDERR, so they work
-; regardless of which bank is currently paged in.
+; to bank 0 via CHGBNK_KEEP_AF (in doshead, mirrored across all kernel
+; banks) before jumping to KABR/KDERR, so they work regardless of which
+; bank is currently paged in.
+;
+; A must be preserved across the bank switch: KABR's caller (the disk
+; error abort path) passes the .ABORT marker in A, and DBABORT_ROUTINE
+; needs to see it to distinguish a disk-error abort from a Ctrl-STOP.
+; The original "xor a / call CHGBNK" sequence set A to 0, which made
+; CPABORT_ROUTINE skip the "fetch original error from B" branch and the
+; whole disk-error abort path silently fell through to READYR.
 ;
 KABJ_HOOKS_TEMPLATE::
-		xor	a
-		call	7FD0h		;CHGBNK - switch to bank 0
+		call	CHGBNK_KEEP_AF##
 		jp	KABR
-		xor	a
-		call	7FD0h		;CHGBNK - switch to bank 0
+		call	CHGBNK_KEEP_AF##
 		jp	KDERR
+KABJ_HOOKS_TEMPLATE_END::
 ;
 ;
 ;-----------------------------------------------------------------------------

--- a/source/kernel/bank0/doshead.mac
+++ b/source/kernel/bank0/doshead.mac
@@ -112,6 +112,23 @@ CALDRV:
 ;
 ;-----------------------------------------------------------------------------
 ;
+; Switch to bank 0 while preserving AF (and all other registers).
+; Used by the KABJ/KDERJ page-3 RAM hooks: those hooks are invoked from
+; an unknown kernel bank, and must end up in bank 0 (where KABR/KDERR live)
+; with A still holding the .ABORT/.STOP/error marker the caller supplied.
+;
+; This routine lives inside the doshead area (4000h-40FEh) which the Makefile
+; copies byte-for-byte into every kernel bank, so "call CHGBNK_KEEP_AF" from
+; the page-3 RAM hook works regardless of which kernel bank happens to be
+; paged in page 1. The 7FD0h-7FFFh range can't be used for this because it's
+; reserved for the OEM/driver CHGBNK implementation.
+
+CHGBNK_KEEP_AF::
+		push	af
+		xor	a
+		call	7FD0h		;CHGBNK - select bank 0
+		pop	af
+		ret
 
 		defs	ROMST+78h-$,0FFh
 ;

--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -1492,7 +1492,7 @@ FILAUX:	ld	(hl),0C9h
 	ld	($PROMPT##),hl	; disk change prompt routine.
 	ld	hl,KABJ_HOOKS_TEMPLATE##	;Copy KABJ/KDERJ hook code
 	ld	de,KABJ_CODE##			; to page 3 RAM so the hooks
-	ld	bc,14				; are ready before any BDOS
+	ld	bc,KABJ_HOOKS_TEMPLATE_END##-KABJ_HOOKS_TEMPLATE##	;are ready before any BDOS
 	ldir					; call can happen.
 ;
 	ld	hl,BDOS_GO##

--- a/source/kernel/bank1/mapinit.mac
+++ b/source/kernel/bank1/mapinit.mac
@@ -75,8 +75,16 @@ endif
 		ret
 DO_MAPINIT:
 
-		call	MAP_SCAN		;This is the second time round
-		ret	c			; MAP_SCAN is called.
+		;Reuse the MAP_SCAN result captured by the earlier MEM_CHK call
+		;instead of re-probing the mapper. Repeating the destructive
+		;AAh/55h probe at this point (which is what MSX-DOS 2 and Nextor 2 did)
+		;breaks on Turbo-R due to the changes introduced in Nextor 3:
+		;BIOS calls made between the two scans (INITXT, console prints)
+		;leave the firmware in a state where writes to the top 4 segments (the
+		;ROM-image shadow at 12-15) no longer survive the read-back,
+		;so the second scan would find four less segment in the primary mapper.
+		;The first scan ran before those BIOS calls and saw the mapper correctly.
+		ld	hl,(MAP_REC_END_PTR##)
 ;
 ;
 ;    *****  ALLOCATE AND BUILD UP MAP_TAB IN PAGE-3  *****
@@ -389,6 +397,9 @@ not_exp_slot_2:	inc	hl
 		inc	hl
 		call	SWAP_RAM_SLOT		; the RAM slot.
 		pop	hl
+		ld	(MAP_REC_END_PTR##),hl	;Save end-of-records pointer so
+						; MAP_INIT can reuse this scan's
+						; result instead of re-probing.
 		xor	a
 		ret
 ;

--- a/source/kernel/bank6/idrvauto.mac
+++ b/source/kernel/bank6/idrvauto.mac
@@ -460,7 +460,7 @@ IDRV_PARSED:
 	ld	b,00110000b		;Try mappers other than primary first
 	call	ALL_SEG##
 	jr	nc,IDRV_ALLOK
-	ld	e,70		;"Not enough memory"
+	ld	e,7		;ERROM, "Out of memory"
 	jp	BASIC_ERR6
 
 IDRV_ALLOK:

--- a/source/kernel/data.mac
+++ b/source/kernel/data.mac
@@ -419,9 +419,6 @@ ram_ad	defl	DATABASE
 	const	SLTTBL,0FCC5h		;Secondary slot register images
 	const	KBUF,  0F41Fh		;Buffer space in main MSX work area
 ;
-;	MAP_SCAN temporary scratch.  Copied later to real locations.
-;
-	const	MAP_REC,KBUF		;Temporary mapper record 16*2 + 1
 	const	CH_TYPE,KBUF		;Type of character generator 0...3
 					; (controls upper-casing routine)
 ;

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -297,8 +297,8 @@ size	macro	name
     field  5,BOOTKEYS              ;To store the state of boot keys
     field  1,I_AM_RUSSIAN
     field  1,ALL_KERNELS_DISABLED
-    field  7,KABJ_CODE              ;RAM hook: xor a + call CHGBNK + jp KABR
-    field  7,KDERJ_CODE             ;RAM hook: xor a + call CHGBNK + jp KDERR
+    field  6,KABJ_CODE              ;RAM hook: call CHGBNK_KEEP_AF + jp KABR
+    field  6,KDERJ_CODE             ;RAM hook: call CHGBNK_KEEP_AF + jp KDERR
 
     ;Mapper scan scratch. Populated by the early MAP_SCAN call in MEM_CHK
     ;and re-read (instead of re-scanning) by MAP_INIT. Lives here, in the

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -299,6 +299,15 @@ size	macro	name
     field  1,ALL_KERNELS_DISABLED
     field  7,KABJ_CODE              ;RAM hook: xor a + call CHGBNK + jp KABR
     field  7,KDERJ_CODE             ;RAM hook: xor a + call CHGBNK + jp KDERR
+
+    ;Mapper scan scratch. Populated by the early MAP_SCAN call in MEM_CHK
+    ;and re-read (instead of re-scanning) by MAP_INIT. Lives here, in the
+    ;BOOT_TMP region, because the previous location (KBUF, F41Fh) is part
+    ;of the MSX BIOS work area and gets corrupted by INITXT / CHPUT calls
+    ;that now run between the two scans on Turbo-R. The end-of-records
+    ;pointer is what MAP_SCAN would have returned in HL.
+    field  2*16+1,MAP_REC
+    field  2,MAP_REC_END_PTR
 ;
 ;-----------------------------------------------------------------------------
 ;


### PR DESCRIPTION
## Reuse `MAP_SCAN` result from `MEM_CHK` in `MAP_INIT`

`MAP_SCAN` was being run twice during boot: once early from `MEM_CHK` (to verify there's enough mapper memory before allocating any kernel work area) and once again from `MAP_INIT` (to actually build up `MAP_TAB` and the segment lists). The two-pass design comes from MSX-DOS 2, where `MAP_REC` was just temporary scratch in the MSX BIOS work area (`KBUF`, `F41Fh`) and nothing of consequence ran between the two calls.

On Turbo-R that assumption no longer holds. The kernel now makes BIOS calls (`INITXT`, `CHPUT` for the "Press N to show the boot menu" banner) between the two `MAP_SCAN` calls, and these leave the firmware in a state where the destructive `AAh`/`55h` probe in `TEST_MAPPER_SLOT` can no longer write to the top four mapper segments (the ROM-image shadow at segments 12–15 on a 256K machine). The second scan then bails at segment 12 and reports a 192K mapper, leaving the user with 16K of free RAM instead of the expected 80K.

Move `MAP_REC` and a new `MAP_REC_END_PTR` into the `BOOT_TMP` region in `kvar.mac`, well away from anything the MSX BIOS touches. `MAP_SCAN` now stores its end-of-records pointer in `MAP_REC_END_PTR` on success, and `MAP_INIT` reads that pointer instead of re-running the probe. The destructive scan only happens once per boot, before the BIOS calls that perturb the Turbo-R firmware state.

This also drops the redundant second pass on every other machine.

## Preserve `A` through the `KABJ`/`KDERJ` page-3 RAM bank-switch hooks

The hooks did `xor a / call CHGBNK / jp KABR`, which clobbered `A` to 0 before reaching `KABR`. The disk-error abort path relies on `A` arriving at `DBABORT_ROUTINE` as `.ABORT` so `CPABORT_ROUTINE` can fetch the real error code from `B`; with `A` always 0, `CPABORT_ROUTINE` took the "not `.ABORT`" branch and the abort silently fell through to `READYR`, mangling BASIC's interpreter state to the point that the user saw "NEXT without FOR" on a faulty drive instead of the expected "Disk offline".

Add `CHGBNK_KEEP_AF` in the doshead area (mirrored byte-for-byte across all kernel banks at the same address, `4071h`) which wraps `CHGBNK` with `push af / pop af`. The `KABJ`/`KDERJ` hook becomes a plain `call CHGBNK_KEEP_AF / jp KABR`, ending up 1 byte shorter per hook than the original. `7FD0h`–`7FFFh` stays untouched (OEM-reserved `CHGBNK` area). `init.mac` now derives the copy length from `KABJ_HOOKS_TEMPLATE_END`-`KABJ_HOOKS_TEMPLATE` so it self-tracks.

## Fix `CIDRIVER` reporting "Disk offline" instead of "Out of memory"

When the system has no free RAM segments and `ALL_SEG` fails, the no-memory branch in `CIDRIVER` did `ld e,70` with the comment `"Not enough memory"`; but BASIC error 70 is `DEROFF` ("Disk offline"). The intended `ERROM` ("Out of memory") code is 7. The comment was right; the literal was wrong.

`DRVROP.COM` is unaffected because it goes through `F_DRVRO` directly and gets the DOS-level `.NORAM` translated through `GETERR`/`DERR_TAB`; only the BASIC entry point hit the bad literal.
