### PR TITLE
Miscellaneous fixes 2

### DIFF
--- a/source/kernel/bank0/init.mac
+++ b/source/kernel/bank0/init.mac
@@ -213,6 +213,10 @@ _GO_BIOS:
 ;ASDF for slots 2-0 to 2-3
 ;ZXCV for slots 3-0 to 3-3
 ;For unexpanded slots, the key for subslot 0 applies (U, Q, A, Z)
+;
+;On return C = byte offset and B = bit mask of this slot's disable bit
+;within the boot keys; AFTER_BOOT_MENU relies on this to clear that bit
+;from the RAM boot keys (one-time use), so keep B and C set on return.
 
 DISABLE_KEY:
 	call	GSLOT1##
@@ -965,8 +969,30 @@ AFTER_BOOT_MENU:
 	or	a
 	call	z,INIT_SCREEN_AND_VERSION
 ABM_SKIP_SCREEN:
-	call	DISABLE_KEY
+	call	DISABLE_KEY	;Z=enabled, NZ=disabled; leaves C=byte offset, B=bit mask
 	jr	z,KERNEL_NOT_SKIPPED
+
+	;--- One-time use of RAM boot keys ---
+	;We are being disabled. If our disable bit came from the RAM boot
+	;keys (set by the boot menu or NEXBOOT tool) rather than the keyboard,
+	;clear just that bit now so the disable applies to this boot only:
+	;a soft reset doesn't erase this RAM, so otherwise we'd stay disabled
+	;forever. DISABLE_KEY left C = byte offset and B = bit mask for us.
+	;(When a kernel boots as master the whole keys block is cleared by
+	;CLEAN instead; this path covers the case where no master boots
+	;because every kernel is disabled.)
+	call	SCANKEYS_RAM_AVAILABLE	;Z if the RAM keys signature is present
+	jr	nz,ABM_KEPT_DISABLED	;Keys came from the keyboard: nothing to clear
+	ld	hl,SCANKEYS_RAM_BASE+17	;Start of the 5 boot key bytes
+	ld	e,c
+	ld	d,0
+	add	hl,de			;HL = the key byte holding our disable bit
+	ld	a,b
+	cpl
+	and	(hl)
+	ld	(hl),a			;Clear our disable bit in the RAM boot keys
+ABM_KEPT_DISABLED:
+
 	ld	a,(ALL_KERNELS_DISABLED##)
 	or	a
 	ret	nz		;All disabled: return silently

--- a/source/kernel/bank1/mapinit.mac
+++ b/source/kernel/bank1/mapinit.mac
@@ -1030,10 +1030,9 @@ IS_SUPER_TURBO:
 ;
 ;-----------------------------------------------------------------------------
 ;
-KBUF	equ	0F41Fh			;Buffer space in main MSX work area
-;
 ;   Call the EXTBIO routine of each registered RAM-loaded driver.
-;   Uses KBUF as scratch space for saving/restoring EXTBIO params.
+;   Uses EXB_RAM_SAVE (page 3 system RAM, see kvar.mac) as scratch space for
+;   saving/restoring the EXTBIO params across the inter-segment driver calls.
 ;
 ; Input:  AF/BC/DE/HL = EXTBIO parameters
 ; Output: AF/BC/DE/HL = results (possibly modified by driver)
@@ -1049,12 +1048,12 @@ EXB_RAM_DRV:
 ERAMX_READY:
 	pop	af
 ;
-	ld	(KBUF+2),bc
-	ld	(KBUF+4),de
-	ld	(KBUF+6),hl
+	ld	(EXB_RAM_SAVE##+2),bc
+	ld	(EXB_RAM_SAVE##+4),de
+	ld	(EXB_RAM_SAVE##+6),hl
 	push	af
 	pop	hl
-	ld	(KBUF),hl		;Save AF (H=A, L=F)
+	ld	(EXB_RAM_SAVE##),hl		;Save AF (H=A, L=F)
 ;
 	call	GET_P2##		;Save current page 2 segment
 	push	af
@@ -1086,21 +1085,21 @@ ERAMX_ENT:
 	ld	ix,DRIVER.EXTBIO_ENTRY##
 ;
 	;Restore EXTBIO params for the driver call
-	ld	hl,(KBUF)
+	ld	hl,(EXB_RAM_SAVE##)
 	push	hl
 	pop	af
-	ld	bc,(KBUF+2)
-	ld	de,(KBUF+4)
-	ld	hl,(KBUF+6)
+	ld	bc,(EXB_RAM_SAVE##+2)
+	ld	de,(EXB_RAM_SAVE##+4)
+	ld	hl,(EXB_RAM_SAVE##+6)
 	call	CALL_MAP##
 ;
-	;Save driver's results to KBUF for next iteration/return
-	ld	(KBUF+2),bc
-	ld	(KBUF+4),de
-	ld	(KBUF+6),hl
+	;Save driver's results to EXB_RAM_SAVE for next iteration/return
+	ld	(EXB_RAM_SAVE##+2),bc
+	ld	(EXB_RAM_SAVE##+4),de
+	ld	(EXB_RAM_SAVE##+6),hl
 	push	af
 	pop	hl
-	ld	(KBUF),hl
+	ld	(EXB_RAM_SAVE##),hl
 	;Check IYl (A is free since results already saved)
 	ld_	a,iyl
 	bit	0,a
@@ -1125,12 +1124,12 @@ ERAMX_REST:
 	;No driver handled it, restore page 2 and original params
 	pop	af
 	call	PUT_P2##		;Restore original page 2 segment
-	ld	hl,(KBUF)
+	ld	hl,(EXB_RAM_SAVE##)
 	push	hl
 	pop	af
-	ld	bc,(KBUF+2)
-	ld	de,(KBUF+4)
-	ld	hl,(KBUF+6)
+	ld	bc,(EXB_RAM_SAVE##+2)
+	ld	de,(EXB_RAM_SAVE##+4)
+	ld	hl,(EXB_RAM_SAVE##+6)
 	ret
 ;
 ERAMX_FOUND:
@@ -1138,13 +1137,13 @@ ERAMX_FOUND:
 	pop	af
 	call	PUT_P2##		;Restore original page 2 segment
 	ld	iy,0			;IY=0 (request consumed)
-	;Restore driver's results from KBUF
-	ld	hl,(KBUF)
+	;Restore driver's results from EXB_RAM_SAVE
+	ld	hl,(EXB_RAM_SAVE##)
 	push	hl
 	pop	af
-	ld	bc,(KBUF+2)
-	ld	de,(KBUF+4)
-	ld	hl,(KBUF+6)
+	ld	bc,(EXB_RAM_SAVE##+2)
+	ld	de,(EXB_RAM_SAVE##+4)
+	ld	hl,(EXB_RAM_SAVE##+6)
 	ret
 ;
 ;

--- a/source/kernel/kvar.mac
+++ b/source/kernel/kvar.mac
@@ -300,6 +300,14 @@ size	macro	name
     field  6,KABJ_CODE              ;RAM hook: call CHGBNK_KEEP_AF + jp KABR
     field  6,KDERJ_CODE             ;RAM hook: call CHGBNK_KEEP_AF + jp KDERR
 
+    ;Runtime scratch for EXB_RAM_DRV (mapinit.mac): the 8 bytes of EXTBIO
+    ;parameters (AF/BC/DE/HL) saved/restored across the inter-segment calls to
+    ;the RAM-loaded drivers. It deliberately overlays MAP_REC to avoid claiming
+    ;more page 3 RAM: MAP_REC is only used at boot (MAP_SCAN/MAP_INIT, before any
+    ;driver is loaded) and EXB_RAM_SAVE only afterwards (once a RAM driver is
+    ;installed), so the two never coexist.
+    field  0,EXB_RAM_SAVE
+
     ;Mapper scan scratch. Populated by the early MAP_SCAN call in MEM_CHK
     ;and re-read (instead of re-scanning) by MAP_INIT. Lives here, in the
     ;BOOT_TMP region, because the previous location (KBUF, F41Fh) is part


### PR DESCRIPTION
## Fix boot menu disable keys surviving a soft reset

Disable keys set via the boot menu are stored in a RAM block at A100h, which a non-destructive reset doesn't erase. That block was only cleared by CLEAN, which runs when a kernel becomes the master. When a kernel disables itself and no master ends up booting (e.g. the only kernel is disabled, so the machine boots straight to BASIC), CLEAN never runs and the keys persist: on the next soft reset the kernel reads its disable bit again and stays disabled forever, without the menu ever reappearing.

Make the disable single-use: when a kernel is disabled and its disable bit came from the RAM boot keys (rather than a physically held keyboard key), clear just that bit in the RAM keymap. AFTER_BOOT_MENU reuses the byte offset and mask that DISABLE_KEY already computes. Each kernel clears only its own bit, so disabling several kernels still works within the same boot, and this also makes NEXBOOT's per-slot disables one-time.

Known minor case: if every Nextor kernel is disabled, no master boots on that boot, so the other boot keys (boot to BASIC, disable MSX-DOS kernels...) still apply on the following boot before a master boots and CLEAN clears the whole block. This self-heals within one extra boot and only affects the (pointless) combination of disabling all kernels while also changing the boot process.


## Fix spurious BASIC "Syntax error" when a RAM driver is installed

With at least one RAM-loaded driver installed, EXB_RAM_DRV (mapinit.mac) used KBUF (F41Fh) as scratch to save the EXTBIO parameters (AF/BC/DE/HL) across the inter-segment driver calls. But KBUF is the MSX BIOS line buffer: while Disk BASIC is active it holds the tokenized direct command, so the writes to KBUF+2..+7 land on the line link and line number that BASIC reads after a short statement. Typing CLS then cleared the screen and raised a spurious "Syntax error in NNNN" (NNNN being the leftover DE value). It happened with any RAM driver, regardless of mapped drives, and went away once the last driver was uninstalled.

This is the same hazard already fixed for MAP_REC (moved out of KBUF for the same reason); EXB_RAM_DRV was missed.

Move the 8-byte scratch to EXB_RAM_SAVE in page-3 system RAM. It overlays MAP_REC, which is safe because MAP_REC is only used at boot (MAP_SCAN / MAP_INIT, before any driver is loaded) and EXB_RAM_SAVE only afterwards (once a RAM driver is installed), so the two never coexist and no extra RAM is claimed.
