### PR TITLE
Fix drive mapping and error reporting for partitionless and offline devices

### DIFF
--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -451,6 +451,10 @@ bank5/fdisk.dat: \
 	sdcc -o bank5/ --code-loc 0x4120 --data-loc 0x8020 -mz80 --disable-warning 196 --disable-warning 84 --disable-warning 85 \
 	     --max-allocs-per-node 1000 --allow-unsafe-read --opt-code-size --no-std-crt0 -I../../sdk/C/includes -I../../sdk/C/code bank5/fdisk_crt0.rel bank5/asmcall.rel bank5/printf.rel $(patsubst %.dat,%.c,$@)
 	$(call hex2bin,$(patsubst %.dat,%.ihx,$@),$@)
+	@codesize=$$(printf "%d" 0x$$(grep 'l__CODE' $(patsubst %.dat,%.map,$@) | head -1 | awk '{print $$1}')); \
+	if [ $$codesize -gt 16048 ]; then \
+		echo "ERROR: FDISK code segment is $$codesize bytes; max is 16048 (4120h up to CHGBNK at 7FD0h), the excess would be silently truncated"; exit 1; \
+	fi
 
 bank5/fdisk_crt0.rel: \
 	bank5/fdisk_crt0.s

--- a/source/kernel/bank2/kinit.mac
+++ b/source/kernel/bank2/kinit.mac
@@ -117,6 +117,7 @@ wr_secondary:	ld	(0FFFFh),a	;Write out new value
 ; On error, returns Cy=1 and A=error code starting at 4.
 ;
 		ld	iy,RAM_BASE##		;Setup IY for addressability
+		ld	(iy+@RW_FLAGS##),0
 ;
 ;	+++++  SETUP RAMDISK UNIT DESCRIPTOR  +++++
 ;

--- a/source/kernel/bank2/val.mac
+++ b/source/kernel/bank2/val.mac
@@ -648,6 +648,9 @@ NEW_BOOT_SZ	equ	$-NEW_BOOT
         pop hl
 		or	a			; UPB for this unit.
         jr z,valfib2
+		call	HAS_UPB			;Don't take the shortcut if UD_TIME is set
+		jr	z,valfib2		; but no UPB was ever built (non-FAT disk
+						; previously seen by _RDDRV or _WRDRV)
 		call	IS_FIXED_OR_LOCKED		;Skip all if disk is fixed or locked
 		ld	a,0
         pop hl
@@ -767,6 +770,10 @@ if 1 ;900725	;Was "if 0" in DOS 2.3x
 		jr	z,got_new_volid		; to assume current disk.
 endif
 ;
+		call	HAS_UPB			;If UD_TIME is set but no UPB was ever
+		jr	z,no_curr_upb		; built (non-FAT disk previously seen by
+						; _RDDRV or _WRDRV), always get a new UPB
+;
 		dec	a			;If timeout is 1 then always
 		jr	z,no_curr_upb		; get a new UPB.
 		dec	a			;If timeout >2 then assume
@@ -791,6 +798,12 @@ no_curr_upd_done:
 		jr	z,ignore_wfile
 		call	SET_TIMEOUT		;Don't try to parse FAT boot sector
 		jr	no_dos_disk		;if the disk is not FAT at all
+		;Note: in this state ("valid but non-FAT disk", entered via _RDDRV
+		;or _WRDRV) UD_TIME is set but no UPB exists and the FAT12/FAT16
+		;flags in UD_FLAGS remain clear. The validation shortcut paths
+		;check those flags (via HAS_UPB) so that file operations on such
+		;a drive always retry BUILD_UPB and report "not a DOS disk"
+		;instead of silently working over an empty UPB.
 ;
 ignore_wfile:	call	NEW_UPB			;Set up the unit descriptor.
 		pcall	INV_UD			;Invalidate any old buffers
@@ -854,6 +867,30 @@ CHECK_MNT:
 		ex	(sp),ix
 		bit	UF_MNT,(ix+UD_FLAGS##)
 		ex	(sp),ix
+		pop	hl
+		ret
+
+
+; Check whether a unit descriptor holds a valid UPB: every UPB accepted by
+; the system is FAT12 or FAT16, so at least one of the corresponding flags
+; is set in UD_FLAGS whenever NEW_UPB has been run for the unit. A unit with
+; UD_TIME set but none of these flags set is a "valid but non-FAT disk" as
+; seen by _RDDRV or _WRDRV (see no_curr_upd_done above).
+;
+; Entry:     HL = Unit descriptor
+; Returns:   Z => no UPB, NZ => UPB exists
+; Preserves: A, BC, DE, HL
+
+HAS_UPB:
+		push	hl
+		push	de
+		ld	de,UD_FLAGS##
+		add	hl,de
+		ld	e,a		;Preserve A across the check
+		ld	a,(hl)
+		and	UFM_F2+UFM_F6
+		ld	a,e		;(doesn't affect the Z flag from the AND)
+		pop	de
 		pop	hl
 		ret
 ;

--- a/source/kernel/bank3/dos1ker.mac
+++ b/source/kernel/bank3/dos1ker.mac
@@ -8648,7 +8648,8 @@ A72BD:	ld	a,(hl)
 	ld	l,a
 	jp	(hl)
 
-	; Note: T72C2 covers the classic DiskROM error codes 0-6 only, which is
+	; Note: T72C2 covers the classic DiskROM error codes 0-6 only
+	; (received doubled, with the write flag in bit 0), which is
 	; fine because this handler is used in DOS 1 mode only (in DOS 2 mode
 	; DISKVECT points to DBERR in bank 0 instead, see SET_DISKBASIC in
 	; init.mac) and the DOS 1 kernel never generates codes outside 0-6.

--- a/source/kernel/bank3/dos1ker.mac
+++ b/source/kernel/bank3/dos1ker.mac
@@ -8648,6 +8648,11 @@ A72BD:	ld	a,(hl)
 	ld	l,a
 	jp	(hl)
 
+	; Note: T72C2 covers the classic DiskROM error codes 0-6 only, which is
+	; fine because this handler is used in DOS 1 mode only (in DOS 2 mode
+	; DISKVECT points to DBERR in bank 0 instead, see SET_DISKBASIC in
+	; init.mac) and the DOS 1 kernel never generates codes outside 0-6.
+
 T72C2:	defw	A71AE			; Write Protect error, disk write protect error
 	defw	A71B4			; Not Ready error, disk offline error
 	defw	A71B1			; Data/CRC error, disk i/o error

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -844,14 +844,28 @@ SETNUMD_NOUD:
 ; If there is a device having a partition that is properly formatted in FAT12
 ; or FAT16 and has the "active" flag set (the MSB of the first byte
 ; of the partition table entry), then this device and that partition will be assigned
-; regardless of the device number. If there are more than one devices matching this, 
+; regardless of the device number. If there are more than one devices matching this,
 ; the one with the smallest device number will be assigned. If there are multiple
 ; active partitions in the same device, the first one found will be assigned.
 ;
+; If no device with a suitable partition is found, the drive is attached to
+; a fallback device, if one was found during the scan, with no partition
+; assigned (UF_FOK not set in DOS 2 mode, first absolute sector -1 in DOS 1
+; mode); a partition will then be searched on the first access to the drive.
+; A fallback device is one that is either offline and removable, or online
+; but without any valid filesystem on it (this honors the drive that
+; GET_BOOT_DRIVES_COUNT reserves for such devices). If there are multiple
+; fallback devices, the one with the smallest device number is chosen.
+;
 ; There is also a second entry point, AUTO_ASPART.
 ; The difference is that this one searches for a suitable partition,
-; but the device is fixed (passed as parameter).
-; This one is used if the device provides its own configuration.
+; but the device is fixed (passed as parameter). In this mode the
+; "online with no valid filesystem" fallback doesn't apply (an error is
+; returned instead), but the "offline and removable" one does.
+;
+; Note: candidate and fallback device numbers are stored in a byte whose
+; bits 6 and 7 hold the floppy and removable flags, so the automatic
+; search fully supports device numbers 1 to 63 only.
 ;
 ; Input:  HL = DOS 2 mode: 
 ;                  Address of unit descriptor, it must have UD_SLOT and UD_PHYSICAL_UNIT set
@@ -876,12 +890,16 @@ AAD_CURR_PART_DEVNUM equ 4
 AAD_CURR_PART_INDEX equ 5 ;Bit 7 set when examining extended partitions, FFh when examining the MBR
 AAD_CURR_PART_SECTOR equ 6
 AAD_CURR_PART_STATUS_BYTE equ 10
-AAD_CAND_PART_DEVNUM equ 11
+AAD_CAND_PART_DEVNUM equ 11 ;bit 7: removable, bit 6: floppy
+AAD_SAW_VALID_PART equ 19
 AAD_CAND_PART_SECTOR equ 12
 AAD_FLAGS equ 16
 AAD_MAX_DEVICE_NUM equ 17
+AAD_FALLBACK_DEVNUM equ 18 ;bit 7: removable, bit 6: floppy
+AAD_SAW_VALID_PART equ 19  ;Nonzero if the device currently being examined
+                           ;holds at least one valid filesystem
 
-AAD_SIZE equ 18
+AAD_SIZE equ 20
 
 AAFLAG_ENTER_EMU_MODE equ 0
 AAFLAG_IS_AUTOASPART equ 7
@@ -961,11 +979,13 @@ AUTO_NOEMU:
 
     bit 7,d
 	jr z,AUTO_COMMON3
-	
+
 	ld (ix+AAD_LOOP_DEVICE_NUMBER),b
 	xor a
 	ld (ix+AAD_CAND_PART_DEVNUM),a
 	ld (ix+AAD_CURR_PART_DEVNUM),a
+	ld (ix+AAD_FALLBACK_DEVNUM),a
+	ld (ix+AAD_SAW_VALID_PART),a
 
 	jp AA_GET_DEVINFO
 
@@ -973,6 +993,7 @@ AUTO_COMMON3:
 	xor a
 	ld (ix+AAD_CAND_PART_DEVNUM),a
 	ld (ix+AAD_CURR_PART_STATUS_BYTE),a
+	ld (ix+AAD_FALLBACK_DEVNUM),a
 
 	;Start at device number = 1 (A=0 then INC A)
 AA_DLOOP:
@@ -981,6 +1002,7 @@ AA_DLOOP:
 
 	xor	a
 	ld	(ix+AAD_CURR_PART_DEVNUM),a
+	ld	(ix+AAD_SAW_VALID_PART),a
 
 	;--- Note: earlier there was a device-level duplicate check here, 
 	;    but that's no longer needed: the drive-per-partition feature allows multiple
@@ -1114,31 +1136,15 @@ AA_PX_1ST:
     jr z,AA_PX_POK
 
     ;F_GPART failed (device not ready):
-    ;Check if device is removable, if so, assign it anyway
-	;(if later the device becomes online a partition will be assigned on first access)
+    ;If the device is removable, record it as the fallback device:
+    ;it will be attached to the drive, with no partition assigned,
+    ;if no suitable partition is found in any device
+    ;(when the device becomes online a partition will be assigned on first access).
+    ;Note that we don't assign it right away: a device holding an actual
+    ;filesystem, even a not active one found later in the scan, takes precedence.
     bit 7,(ix+AAD_CURR_PART_DEVNUM)
     jp z,AA_LLOOP_NEXT	;Not removable: try next device
-
-    ;Check if this offline removable device is already assigned to another drive
-    push ix
-    push iy
-    ld h,(ix+AAD_DRIVER_SLOT)
-    ld l,0FFh
-    ld e,(ix+AAD_UNIT_DESCRIPTOR)
-    ld d,(ix+AAD_UNIT_DESCRIPTOR+1)
-    push de
-    ld d,(ix+AAD_LOOP_DEVICE_NUMBER)
-    exx
-    ld de,0FFFFh
-    ld hl,0FFFFh
-    exx
-    pop ix
-    call CHECK_MAP_IN_USE
-    pop iy
-    pop ix
-    jp nz,AA_LLOOP_NEXT	;Already assigned: skip to next device
-
-    jp AA_ASSIGN_OFFLINE_REMOVABLE	;Removable: assign in offline mode
+    jp AA_RECORD_FALLBACK
 AA_PX_POK:
 
     ;--- If we are scanning the first partition and bit 0 of status byte is set, try to enter disk emulation mode
@@ -1243,7 +1249,7 @@ AA_PX_NOEX:
 AA_PLOOP_NEXT:
     ld a,(ix+AAD_CURR_PART_INDEX)
     inc a     ;FFh if no more partitions left (we were examining the MBR itself)
-    jp z,AA_LLOOP_NEXT
+    jp z,AA_DEV_EXHAUSTED
     cp 5    ;We examine the first 4 primary partitions only...
     jp c,AA_PXLOOP
     bit 7,a
@@ -1295,6 +1301,11 @@ AA_CHECK_BOOT2:
 	cp	4
 	jp	nc,AA_PLOOP_NEXT	;AA_LLOOP_NEXT
 AA_SPC_OK:
+
+	;* The device holds at least one valid filesystem:
+	;  it must not be considered for a fallback assignment
+
+	ld	(ix+AAD_SAW_VALID_PART),1
 
 	;* Check if the partition is already mapped to another drive
 
@@ -1356,6 +1367,53 @@ AA_NOT_ACTIVE:
 
     jp  AA_PLOOP_NEXT
 
+	;--- The current device has been scanned completely (including the MBR
+	;    itself as a last resort) and no mappable partition was found on it.
+	;    If it doesn't hold any valid filesystem at all (not even one already
+	;    mapped to another drive), record it as the fallback device: it will be
+	;    attached to the drive, with no partition assigned, if no suitable
+	;    partition is found in any device. This honors the drive that
+	;    GET_BOOT_DRIVES_COUNT reserves for partitionless devices, and a
+	;    partition will be searched on the first access to the drive
+	;    (e.g. after the device gets partitioned).
+
+AA_DEV_EXHAUSTED:
+	bit	AAFLAG_IS_AUTOASPART,(ix+AAD_FLAGS)
+	jp	nz,AA_LLOOP_NEXT	;Fixed device requested: keep the "no suitable partition" error
+
+AA_RECORD_FALLBACK:
+	ld	a,(ix+AAD_SAW_VALID_PART)
+	or	a
+	jp	nz,AA_LLOOP_NEXT	;The device holds some filesystem: don't use it as fallback
+
+	ld	a,(ix+AAD_FALLBACK_DEVNUM)
+	or	a
+	jp	nz,AA_LLOOP_NEXT	;We already have a fallback device
+
+	;Check if the device is already attached (with no partition) to another drive
+
+	push	ix
+	push	iy
+	ld	h,(ix+AAD_DRIVER_SLOT)
+	ld	l,0FFh
+	ld	e,(ix+AAD_UNIT_DESCRIPTOR)
+	ld	d,(ix+AAD_UNIT_DESCRIPTOR+1)
+	push	de
+	ld	d,(ix+AAD_LOOP_DEVICE_NUMBER)
+	exx
+	ld	de,0FFFFh
+	ld	hl,0FFFFh
+	exx
+	pop	ix
+	call	CHECK_MAP_IN_USE
+	pop	iy
+	pop	ix
+	jp	nz,AA_LLOOP_NEXT	;Already attached to another drive: skip to next device
+
+	ld	a,(ix+AAD_CURR_PART_DEVNUM)
+	ld	(ix+AAD_FALLBACK_DEVNUM),a
+	jp	AA_LLOOP_NEXT
+
 	;--- No suitable partitions in the current device,
 	;    so jump to the next device
 
@@ -1369,16 +1427,51 @@ AA_LLOOP_NEXT:
 AA_LLOOP_END:
 
 	;--- No more devices found:
-	;    If a candidate device was identified, use it,
-	;    otherwise return an error
+	;    If a candidate device was identified, use it;
+	;    otherwise, if a fallback device was recorded, attach it
+	;    to the drive with no partition assigned;
+	;    otherwise return an error.
 
 	ld	a,(ix+AAD_CAND_PART_DEVNUM)
 	or	a
-	jr	z,AA_END_NOFOUND
+	jr	z,AA_TRY_FALLBACK
 
-	and	111b	;A=Device
+	and	111111b	;A=Device (bits 6-7 hold the removable and floppy flags)
 	ld	(ix+AAD_LOOP_DEVICE_NUMBER),a
 	jp	AA_DO_ASSIGN
+
+	;--- Attach the fallback device to the drive, with no partition assigned.
+	;    The device is either offline and removable, or online but without
+	;    any valid filesystem. Since UF_FOK won't be set (DOS 2 mode),
+	;    BUILD_UPB will search for a partition on the first access to the drive.
+
+AA_TRY_FALLBACK:
+	ld	a,(ix+AAD_FALLBACK_DEVNUM)
+	or	a
+	jr	z,AA_END_NOFOUND
+
+	ld	(ix+AAD_CAND_PART_DEVNUM),a	;So that AA_DO_ASSIGN retrieves the removable and floppy flags
+	and	111111b	;A=Device (bits 6-7 hold the removable and floppy flags)
+	ld	(ix+AAD_LOOP_DEVICE_NUMBER),a
+
+	;Set partition sector to -1.
+	;In DOS 1 mode this means "no partition assigned".
+	;Otherwise it doesn't matter since UF_FOK won't be set.
+	ld	a,0FFh
+	ld	(ix+AAD_CAND_PART_SECTOR),a
+	ld	(ix+AAD_CAND_PART_SECTOR+1),a
+	ld	(ix+AAD_CAND_PART_SECTOR+2),a
+	ld	(ix+AAD_CAND_PART_SECTOR+3),a
+
+	ld	l,(ix+AAD_UNIT_DESCRIPTOR)
+	ld	h,(ix+AAD_UNIT_DESCRIPTOR+1)
+	push	hl
+	pop	iy
+
+	ld	a,(DOS_VER##)
+	or	a
+	jp	z,AA_DO_ASSDOS1
+	jp	AA_DO_ASSIGN_NO_FOK
 
 AA_END_NOFOUND:
 	ld	a,1
@@ -1478,37 +1571,6 @@ AA_DO_ASSDOS1:
 
 	xor	a
 	ret
-
-
-	;--- Assign a removable device to the drive without partition info.
-	;    The partition will be assigned on first access (by BUILD_UPB).
-	;    This is used when a removable device is offline at boot time.
-	;    Reuses AA_DO_ASSIGN but skips setting UF_FOK for DOS 2 mode.
-
-AA_ASSIGN_OFFLINE_REMOVABLE:
-	ld a,(ix+AAD_CURR_PART_DEVNUM)
-	ld (ix+AAD_CAND_PART_DEVNUM),a
-
-	;Set partition sector to -1
-	;In DOS 1 mode this means "no partition assigned".
-	;Otherwise it doesn't matter since UF_FOK won't be set.
-	ld a,0FFh
-	ld (ix+AAD_CAND_PART_SECTOR),a
-	ld (ix+AAD_CAND_PART_SECTOR+1),a
-	ld (ix+AAD_CAND_PART_SECTOR+2),a
-	ld (ix+AAD_CAND_PART_SECTOR+3),a
-
-	ld l,(ix+AAD_UNIT_DESCRIPTOR)
-	ld h,(ix+AAD_UNIT_DESCRIPTOR+1)
-	push hl
-	pop iy
-
-	;Jump to AA_DO_ASSIGN but skip setting UF_FOK for DOS 2 mode
-	;(UF_FOK not set means BUILD_UPB will auto-assign partition on first access)
-	ld a,(DOS_VER##)
-	or a
-	jp z,AA_DO_ASSDOS1
-	jp AA_DO_ASSIGN_NO_FOK
 
 
     ;Try to enter emulation mode from data in RAM
@@ -2958,6 +3020,10 @@ UNMAP_NEXT2:
 ; media inserted. Also, no checking is done for the presence of
 ; an actual filesystem in the start sector specified.
 ;
+; A start sector of FFFFFFFFh has a special meaning: the drive is
+; attached to the device with no partition assigned, and one will be
+; searched automatically on the first access to the drive.
+;
 ; All file handles related to a given drive are closed prior to changing
 ; the mapping state of that drive.
 ;
@@ -3442,9 +3508,16 @@ MAPS_DONE_GS:
 	or	a
 	jp	nz,MAP_IDEVN_END
 
+	;Status 0 means "device exists but is currently not available"
+	;(e.g. an offline removable device). Mapping a drive to such a device
+	;is allowed (the access to the drive will throw a "not ready" error
+	;while the device remains offline), so treat it as unchanged media.
+	;Note that in Nextor 2 status 0 meant "invalid device or logical unit",
+	;which is why this case used to abort the mapping with a .NRDY error.
+
 	ld a,d
 	or a
-	jp z,MAP_IDEVN_NDRY
+	jr z,MAP_DRV_UNCH
 
 	dec	a
 	jr	z,MAP_DRV_UNCH
@@ -3507,13 +3580,27 @@ MAP_DRV_UNCH:
 	ld	a,(iy+7)
 	ld	(ix+UD_FIRST_DEVICE_SECTOR##+3),a
 
+	;Check if the requested start sector is FFFFFFFFh, meaning
+	;"no partition assigned": UF_FOK is not set in that case, so that
+	;a partition is searched on the first access to the drive
+
+	ld	a,(ix+UD_FIRST_DEVICE_SECTOR##)
+	and	(ix+UD_FIRST_DEVICE_SECTOR##+1)
+	and	(ix+UD_FIRST_DEVICE_SECTOR##+2)
+	and	(ix+UD_FIRST_DEVICE_SECTOR##+3)
+	inc	a
+	ld	e,UFM_DB+UFM_FO	;Nextor drive + first sector OK
+	jr	nz,MAP_SPEC_SETFLAGS
+	ld	e,UFM_DB	;Start sector is -1: first sector not OK
+MAP_SPEC_SETFLAGS:
+
 	ld	iy,($SECBUF##)
 	ld	a,(iy+7)
 	ld	d,a		;Save device flags
 	and	1		;Bit 0 = removable
 	rlca
 	rlca			;-> bit 2 = UF_RM
-	or	UFM_DB+UFM_FO	;Nextor drive + first sector OK
+	or	e		;Nextor drive, plus first sector OK unless sector is -1
 	bit	2,d		;FDD flag?
 	jr	z,MAP_SPEC_NOFDD
 	or	UFM_FD		;Set floppy disk flag
@@ -3526,10 +3613,6 @@ MAP_SPEC_NOFDD:
 
 MAP_IDEVN_END:
 	ld	a,.IDEVN##
-	jp	SETNUMDRV
-
-MAP_IDEVN_NDRY:
-	ld	a,.NRDY##
 	jp	SETNUMDRV
 
 
@@ -4762,6 +4845,11 @@ DOSV1_2:
 ; _MAPDRV("x:", -2)
 ;  Map drive to default value
 ;
+; _MAPDRV("x:", -3 [, device [, slot [, segment]]])
+;  Map drive to the device with no partition assigned (a suitable partition
+;  will be searched on the first access to the drive); device, slot and
+;  segment are handled as in the explicit partition mapping variants
+;
 ; _MAPDRV("x:", part)
 ;  Map drive to partition "part" on current driver and device
 ;
@@ -4984,12 +5072,30 @@ MAPDRV_NOUNMAP:
 
 MAPDRV_NODEF:
 
+	;* If partition number is -3, skip the partition assignment:
+	;  the drive will be mapped to the device with no partition assigned
+	;  (mapping sector FFFFFFFFh), and a suitable partition will be
+	;  searched on the first access to the drive.
+	;  Useful e.g. to map a drive to an offline removable device.
+
+	dec	de	;DE = -3
+	call	DCOMPR
+	jr	nz,MAPDRV_NOSKIP
+
+	ld	hl,-1
+	ld	(MAPDRV_SEC),hl
+	ld	(MAPDRV_SEC+2),hl
+	jr	MAPDRV_EXPLICIT
+
+MAPDRV_NOSKIP:
 	ld	a,(MAPDRV_PAR+1)
 	or	a
 	ld	e,78
 	jp	nz,BASIC_ERR	;"Invalid partition" error if >255
 
 	;>>> Explicit partition mapping requested
+
+MAPDRV_EXPLICIT:
 
 	;* If device or slot is 0, we need to get the current mapping status
 
@@ -5029,6 +5135,14 @@ MAPDRV_GOTDEV:
 MAPDRV_GOTSLT:
 
 MAPDRV_NOGETCUR:
+
+	;* If the partition assignment is being skipped (partition number -3),
+	;  the mapping sector is set already
+
+	ld	hl,(MAPDRV_PAR)
+	ld	de,-3
+	call	DCOMPR
+	jp	z,MAPDRV_GOT_PAR_SEC
 
 	ld	a,(MAPDRV_PAR)
 	cp	1
@@ -5145,6 +5259,7 @@ MAPDRV_HELP:
 	db  "             0: device sector zero",13,10
 	db  "             -1: unmap drive",13,10
 	db  "             -2: automatic mapping",13,10
+	db  "             -3: don't set partition",13,10
 	db	"<device>: device number (1-255)",13,10
 	db  "<slot>: of driver, main + 4*sub, or",1
 	db  "        0 for primary controller",13,10
@@ -6666,8 +6781,9 @@ DRVS1NX2:
 ;
 ;    Check if a given candidate partition assignment information is already
 ;    in use in any unit.
-;    Input: IX = Address of target unit descriptor
-;                (will be skipped in the check), DOS 2 mode only
+;    Input: IX = Address of the target unit descriptor (DOS 2 mode) or of the
+;                target entry in the Nextor drives table (DOS 1 mode);
+;                the target itself is skipped in the check
 ;           H  = Driver slot number
 ;           L  = Driver segment number
 ;           D  = Device number
@@ -6781,6 +6897,25 @@ CMIU_DOS1:
 	inc	iy
 
 CMIU1_LOOP:
+	;Skip the entry of the drive being mapped itself (pointed by IX),
+	;as the DOS 2 version does with the target unit descriptor.
+	;Otherwise a drive attached to a device with no partition assigned
+	;(first absolute sector FFFFFFFFh) would block its own re-assignment,
+	;e.g. the offline removable device fallback would fail and any access
+	;to the drive would report "disk i/o error" instead of "disk offline".
+
+	push	de
+	push	ix
+	pop	de
+	ld_	a,iyl
+	sub	e
+	jr	nz,CMIU1_NOTSELF
+	ld_	a,iyh
+	sub	d
+CMIU1_NOTSELF:
+	pop	de
+	jr	z,CMIU1_NEXT
+
 	ld	a,(iy+UD1_SLOT##)
 	cp	h
 	jr	nz,CMIU1_NEXT

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -891,7 +891,6 @@ AAD_CURR_PART_INDEX equ 5 ;Bit 7 set when examining extended partitions, FFh whe
 AAD_CURR_PART_SECTOR equ 6
 AAD_CURR_PART_STATUS_BYTE equ 10
 AAD_CAND_PART_DEVNUM equ 11 ;bit 7: removable, bit 6: floppy
-AAD_SAW_VALID_PART equ 19
 AAD_CAND_PART_SECTOR equ 12
 AAD_FLAGS equ 16
 AAD_MAX_DEVICE_NUM equ 17

--- a/source/kernel/bank5/fdisk.c
+++ b/source/kernel/bank5/fdisk.c
@@ -68,6 +68,7 @@ byte screenLinesCount;
 partitionInfo partitions[MAX_PARTITIONS_TO_HANDLE];
 int partitionsCount;
 bool partitionsExistInDisk;
+bool partitionsDeletedFromDisk;
 ulong unpartitionnedSpaceInSectors;
 bool canCreatePartitions;
 bool canDoDirectFormat;
@@ -594,6 +595,7 @@ void InitializePartitioningVariables(byte deviceIndex)
 	selectedDeviceParams = &selectedDevice->params;
 	partitionsCount = 0;
 	partitionsExistInDisk = true;
+	partitionsDeletedFromDisk = false;
 	canCreatePartitions = (selectedDeviceParams->sectorCount >= (MIN_DEVICE_SIZE_FOR_PARTITIONS_IN_K * 2));
 	canDoDirectFormat = (selectedDeviceParams->sectorCount <= MAX_DEVICE_SIZE_FOR_DIRECT_FORMAT_IN_K * 2);
 	unpartitionnedSpaceInSectors = selectedDeviceParams->sectorCount;
@@ -669,6 +671,7 @@ void GoPartitioningMainMenuScreen()
 	char key;
 	byte error;
 	bool canAddPartitionsNow;
+	bool canWrite;
 	bool mustRetrievePartitionInfo = true;
 
 	while(true) {
@@ -689,6 +692,7 @@ void GoPartitioningMainMenuScreen()
 					}
 				}
 				partitionsExistInDisk = (partitionsCount > 0);
+				partitionsDeletedFromDisk = false;
 			}
 			mustRetrievePartitionInfo = false;
 		}
@@ -733,15 +737,20 @@ void GoPartitioningMainMenuScreen()
 		if(canDoDirectFormat) {
 			print("F. Format device without partitions\r\n\r\n");
 		}
-		if(!partitionsExistInDisk && partitionsCount > 0) {
-			print("W. Write partitions to disk\r\n\r\n");
+		canWrite =
+			!partitionsExistInDisk &&
+			(partitionsCount > 0 || partitionsDeletedFromDisk);
+		if(canWrite) {
+			print(partitionsCount > 0 ?
+				"W. Write partitions to disk\r\n\r\n" :
+				"W. Write empty partition table\r\n\r\n");
 		}
 
 		PrintStateMessage("Select an option or press ESC to return");
 
 		while((key = WaitKey()) == 0);
 		if(key == ESC) {
-			if(partitionsExistInDisk || partitionsCount == 0) {
+			if(!canWrite) {
 				return;
 			}
 			PrintStateMessage("Discard changes and return? (y/n) ");
@@ -766,7 +775,7 @@ void GoPartitioningMainMenuScreen()
 			if(FormatWithoutPartitions()) {
 				mustRetrievePartitionInfo = true;
 			}
-		}else if(key == 'w' && !partitionsExistInDisk && partitionsCount > 0) {
+		}else if(key == 'w' && canWrite) {
 			if(WritePartitionTable()) {
 				mustRetrievePartitionInfo = true;
 			}
@@ -1013,6 +1022,11 @@ void DeleteAllPartitions()
 		return;
 	}
 
+	if(partitionsExistInDisk) {
+		//The deletion of the partitions that exist on disk can be
+		//committed later by writing an empty partition table with "W"
+		partitionsDeletedFromDisk = true;
+	}
 	partitionsCount = 0;
 	partitionsExistInDisk = false;
 	unpartitionnedSpaceInSectors = selectedDeviceParams->sectorCount;
@@ -1250,18 +1264,41 @@ bool WritePartitionTable()
 	//http://www.rayknights.org/pc_boot/ext_tbls.htm
 
 	int i;
-	//masterBootRecord* mbr = (masterBootRecord*)buffer + 80;
 	byte error;
 
-	sprintf(buffer, "Create %i partitions on device", partitionsCount);
+	if(partitionsCount != 0) {
+		sprintf(buffer, "Create %i partitions on device", partitionsCount);
+	}
 
-	if(!ConfirmDataDestroy(buffer)) {
+	//An empty partition list here means that a
+	//"delete all partitions" operation is being committed
+	if(!ConfirmDataDestroy(partitionsCount == 0 ? "Remove all partitions" : buffer)) {
 		return false;
 	}
 
 	ClearInformationArea();
 	PrintTargetInfo();
 	PrintStateMessage("Please wait...");
+
+	if(partitionsCount == 0) {
+		//Commit the deletion of the existing partitions by writing
+		//a master boot record with an empty partition table.
+		//Unlike the MBR written when partitions are created, this one
+		//must NOT begin with a x86-style jump instruction: the boot
+		//process probes the first sector of each drive and takes a
+		//leading EBh or E9h byte as "this drive holds a boot sector",
+		//which would hijack the boot drive selection. An all-zeros
+		//sector with just the boot signature is a valid empty MBR.
+
+		ClearSectorBuffer();
+		((masterBootRecord*)sectorBuffer)->mbrSignature = 0xAA55;
+
+		if((error = WriteSectorToDevice(0)) != 0) {
+			PrintDosErrorMessage(error, "Error when writing partition table:");
+			WaitKey();
+			return false;
+		}
+	} else {
 
 	Locate(0, MESSAGE_ROW);
 	PrintCentered("Preparing partitioning process...");
@@ -1280,9 +1317,11 @@ bool WritePartitionTable()
 			return false;
 		}
 
-		
+
 	}
-	
+
+	}
+
 	Locate(0, MESSAGE_ROW + 2);
 	PrintDone();
 	RequestPressKeyToReturn();

--- a/source/kernel/bank6/idrvauto.mac
+++ b/source/kernel/bank6/idrvauto.mac
@@ -933,8 +933,9 @@ IAM_UTFOUND:
 	ld	(BUF+2),a	;+2 = device number
 	xor	a
 	ld	(BUF+3),a	;+3 = 0 (was LUN)
-	ld	(BUF+4),a	;+4..+7 = sector 0
-	ld	(BUF+5),a
+	ld	a,0FFh		;+4..+7 = sector FFFFFFFFh: attach the device with no
+	ld	(BUF+4),a	;partition assigned, so that a suitable partition is
+	ld	(BUF+5),a	;searched automatically on the first access to the drive
 	ld	(BUF+6),a
 	ld	(BUF+7),a
 

--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -962,6 +962,17 @@ CONV_ERR:
 	ld	b,2
 	cp	.NRDY##
 	jr	z,CONV_ERR_END
+
+	;This case should never happen because READ_WRITE is supposed to
+	;never return .IDEVN for an existing device (if the device is offilne
+	;it should return .NRDY instead); however in Nextor 2 both cases
+	;were indistinguishable, so drivers not properly ported from Nextor 2
+	;will return .IDEVN instead of .NRDY. This is only relevant for DOS 1 mode
+	;(in DOS 2 mode the media check layer masks this driver defect,
+	;see mc_devcmd_err in val.mac)
+	cp	.IDEVN##
+	jr	z,CONV_ERR_END
+
 	ld	b,4
 	cp	.DATA##
 	jr	z,CONV_ERR_END

--- a/source/kernel/drv.mac
+++ b/source/kernel/drv.mac
@@ -528,7 +528,7 @@ DIO_WR_LOOP:
 	pop	bc
 	pop	hl
 	pop	hl	;Not POP AF, to preserve error info
-	ret
+	jp	CONV_ERR
 
 DIO_WR_OK:
 	pop	de

--- a/source/tools/MAPDRV.MAC
+++ b/source/tools/MAPDRV.MAC
@@ -60,7 +60,7 @@ USAGE_S:
 	db	"MAPDRV - map a drive to a driver, device and partition",13,10
 	db  "         or mount a file on a drive",13,10
 	db	13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [<slot>[-<subslot>][:<segment>]]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [<slot>[-<subslot>][:<seg>]]",13,10
 	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [0]",13,10
 	db  "MAPDRV <drive>: [/]<filename> [/ro]",13,10
 	db	13,10

--- a/source/tools/MAPDRV.MAC
+++ b/source/tools/MAPDRV.MAC
@@ -10,13 +10,13 @@ PT_EXT_LBA: equ 15
 
       ; -------------------------------------------------------------------------------
 	db	13
-	db	"MAPDRV v1.2 - map a drive to a driver, device, LUN and partition,",13,10
+	db	"MAPDRV v1.3 - map a drive to a driver, device and partition,",13,10
 	db      "         or mount a file on a drive"
 	db	13,10
 	db	"Usage:",13,10
 	db	13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [<slot>[-<subslot>][:<segment>]]",13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [0]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [<slot>[-<subslot>][:<seg>]]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [0]",13,10
 	db  "MAPDRV <drive>: [/]<filename> [/ro]",13,10
 	db	13,10
 	db	"Maps the drive to the specified partition of the specified device",13,10
@@ -33,7 +33,7 @@ PT_EXT_LBA: equ 15
 	db	13,10
 	db	"<slot> and <subslot> must be a number from 0 to 3. If 0 is specified instead,",13,10
 	db	"the primary disk controller slot is assumed.",13,10
-	db  "<segment> must be a number from 0 to 255, only used for RAM drivers.",13,10
+	db  "<seg> (segment) must be a number from 0 to 255, only used for RAM drivers.",13,10
 	db	13,10
 	db	"If device information is provided but slot is omitted, the drive is mapped to",13,10
 	db	"the specified partition of the specified device in the driver already",13,10
@@ -46,6 +46,9 @@ PT_EXT_LBA: equ 15
 	db	13,10
 	db	"'d' will revert the drive to its default mapping (the mapping at boot time).",13,10
 	db	"'u' will leave the drive unmapped. Other parameters are ignored in both cases.",13,10
+	db	"'s' will map the drive to the device but skip the partition assignment;",13,10
+	db	"    a suitable partition will be searched on each access to the drive",13,10
+	db	"    (useful for removable devices that are currently offline).",13,10
 	db	13,10
 	db	"If a valid filename is supplied after <drive>, the specified file will be",13,10
 	db      "mapped to the drive. A file cannot be mapped to its own drive, or to a drive",13,10
@@ -54,11 +57,11 @@ PT_EXT_LBA: equ 15
 	db	1Ah
 
 USAGE_S:
-	db	"MAPDRV - map a drive to a driver, device, LUN and partition",13,10
+	db	"MAPDRV - map a drive to a driver, device and partition",13,10
 	db  "         or mount a file on a drive",13,10
 	db	13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [<slot>[-<subslot>][:<segment>]]",13,10
-	db	"MAPDRV [/L] <drive>: <partition>|d|u [<device>] [0]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [<slot>[-<subslot>][:<segment>]]",13,10
+	db	"MAPDRV [/L] <drive>: <partition>|d|u|s [<device>] [0]",13,10
 	db  "MAPDRV <drive>: [/]<filename> [/ro]",13,10
 	db	13,10
 	db	"TYPE MAPDRV.COM for more details.",13,10
@@ -134,7 +137,7 @@ NO_LOCK:
 	ld	a,(BUF+1)
 	or	a
 	jp	nz,IS_FILE
-	ld	a,(BUF)		;Check fo special values "d" and "u"
+	ld	a,(BUF)		;Check fo special values "d", "u" and "s"
 	or	20h
 	cp	"d"
 	ld	b,1
@@ -142,10 +145,21 @@ NO_LOCK:
 	cp	"u"
 	ld	b,0
 	jp	z,DO_MAP_DU
+	cp	"s"
+	jr	z,IS_SKIP_PART
 	jp	IS_FILE
+
+	;* "s": skip the partition assignment,
+	;  then parse device and slot as for a partition number
+
+IS_SKIP_PART:
+	ld	a,-1
+	ld	(SKIP_PART),a
+	jr	IS_PART2
 
 IS_PART:
 	ld	(PARTITION),a
+IS_PART2:
 
 	;* Device
 
@@ -241,6 +255,20 @@ OK_DEVICE:
 	ld	a,(BUF_DRIVER+1)
 	ld	(SEGMENT),a
 OK_GETCURMAP:
+
+	;* If skipping the partition assignment ("s"), use mapping sector
+	;  FFFFFFFFh: the drive will be attached to the device with no
+	;  partition assigned, and a suitable partition will be searched
+	;  on the first access to the drive
+
+	ld	a,(SKIP_PART)
+	or	a
+	jr	z,NO_SKIP_PART
+	ld	hl,-1
+	ld	de,-1
+	jp	OK_PARTINFO
+
+NO_SKIP_PART:
 
 	;* Convert partition to primary or extended as appropriate
 
@@ -451,6 +479,7 @@ BADKER21_MSG:
 	db	"*** File mounting requires Nextor 2.1 or later",13,10,"$"
 
 PARTITION:	db	0
+SKIP_PART:	db	0
 DO_LOCK:	db	0
 DRIVE:	db	0
 PRIMARY:	db	0


### PR DESCRIPTION
This pull request fixes a set of related problems around drives that are attached to a device without a usable filesystem, either because the device has no (mappable) partitions, or because it's a removable device that is currently offline. Reference scenario: a Sunrise IDE master device with no partitions and no filesystem, an absent slave device (declared as removable by the driver), and an internal FDD.

## Summary of user-visible fixes

* At boot time, a device that is online but holds no mappable filesystem now keeps the drive that was reserved for it, attached with no partition assigned. Previously the drive was either destroyed or handed to an offline removable device found later in the scan, shifting all drive letters (in the reference scenario: A: ended up reserved for the absent slave and the master got no drive at all).
* `DRVROP /m` and `CALL IDRIVER` with the auto-map flag now work for partitioned devices. Previously they mapped absolute sector 0 (the MBR) as if it were a filesystem, so any access to the mapped drive failed with "Not a DOS disk".
* `CALL MAPDRV` (with -3 as the partition number) and MAPDRV.COM (with the new "s" partition letter) can now map a drive to a device while skipping the partition assignment. Among other things this makes it possible to map a drive to an offline removable device, which was previously impossible: the partition scan always ran at mapping time and failed with a "not ready" error.
* Accessing a drive attached to a device with no filesystem now reports **Disk I/O error** in Disk BASIC (DOS 2 mode). Previously it reported a bogus "File not found".
* In DOS 1 mode, accessing a drive attached to an offline removable device now reports **Disk offline** instead of "Disk I/O error", matching DOS 2 mode.
* In FDISK, the deletion of the existing partitions of a device can now be committed: after using "delete all partitions", W becomes available as "Write empty partition table". Previously W was only available when at least one partition was defined, so the only way to actually remove all partitions from a device was to create some new partition.
* The kernel makefile is strenghtened: it will fail if the compiled FDISK code overgrows its ROM bank.

## Changes in detail

### Fallback device tier in the boot auto-mapping (`bank4/partit.mac`)

`AUTO_ASSIGN` now records a *fallback device* while scanning: a device that is either offline and removable, or online but without any valid filesystem. If the scan ends without a real partition to assign, the drive is attached to the fallback device with no partition assigned (`UF_FOK` clear in DOS 2 mode, first absolute sector FFFFFFFFh in DOS 1 mode); `BUILD_UPB` then searches for a partition automatically on each access, so the drive becomes usable immediately after the device is partitioned or a medium is inserted, with no reboot needed.

Notes:

* Real filesystems always win: an active partition is still assigned immediately, a valid non-active partition is preferred over any fallback device regardless of device order. Previously the offline-removable case *assigned immediately*, which could steal a drive letter from a valid non-active partition found earlier in the scan.
* Among multiple fallback devices, the lowest device number wins, so drive letters pair with devices in the natural order.
* This makes the mapping phase consistent with `GET_BOOT_DRIVES_COUNT`, which already reserved a minimum of one drive per online device precisely for this case.
* A device whose filesystems are all already mapped to other drives is never used as a fallback (tracked via a new "saw a valid filesystem" flag).
* The candidate device number mask in `AA_LLOOP_END` was widened from `111b` to `111111b` (a Nextor 2 leftover from the 3-bit device index era; device numbers 8-63 were being mangled). Device numbers 64-255 remain outside the reach of the automatic partition search, since bits 6 and 7 of the stored device number hold the removable and floppy flags; this limitation is now documented in the user manual and the driver development guide (on the documentation branch).
* In `AUTO_ASPART` mode (fixed device: `_MAPDRV` B=1 internals, `BUILD_UPB` first-access search) the online-without-filesystem fallback deliberately does not apply, preserving the "no suitable partition" error semantics; the offline-removable fallback still does.

### `_MAPDRV` B=2 accepts start sector FFFFFFFFh (`bank4/partit.mac`, `bank6/idrvauto.mac`, `tools/MAPDRV.MAC`)

A starting sector of FFFFFFFFh in the mapping data now means "attach the drive to the device with no partition assigned" - `MAP_SPECIFIC` skips setting `UF_FOK`, so the first suitable partition is searched on first access. This was already the internal convention for boot-time deferred bindings and the native DOS 1 representation, so the DOS 1 side needed no changes.

`IDRV_AUTOMAP` (the `DRVROP /m` / `CALL IDRIVER` flag 1 implementation) now passes FFFFFFFFh instead of a literal sector 0, making the auto-map useful for partitioned, superfloppy and not-yet-partitioned devices alike.

The feature is also exposed to users: `CALL MAPDRV` accepts -3 as the partition number, and MAPDRV.COM (bumped to v1.3) accepts "s" ("skip partition assignment") in place of the partition number; the device and slot parameters are handled as in the explicit partition mapping variants. This makes it possible to map a drive to an offline removable device (previously the partition scan always ran at mapping time and threw a "not ready" error) or to a device that will be partitioned later.

For this to work with offline devices, `MAP_SPECIFIC` no longer aborts the mapping with a `.NRDY` error when the device reports availability status 0 ("device exists but is currently not available"); it now proceeds treating the media as unchanged. That abort was a Nextor 2 leftover (status 0 meant "invalid device or logical unit" there) and it also contradicted the documented behavior of `_MAPDRV`, which explicitly allows mapping a drive to a removable device with no media inserted.

### Correct errors for filesystem-less drives in DOS 2 mode (`bank2/kinit.mac`, `bank2/val.mac`)

Two combined defects made `FILES` report "File not found" with no disk error ever raised:

* **`RW_FLAGS` was never initialized.** `BUILD_UPB` tests its `RF_DOS2` bit ("running `_RDDRV`/`_WRDRV`") to decide whether to swallow "Not a DOS disk" errors, but the byte is only ever written by the file and absolute-sector I/O functions. Until the first such operation it held power-on RAM garbage, so on many machines the error was silently swallowed for *all* callers. `KINIT` now clears it.
* **The "valid but non-FAT disk" state was cached as if a UPB existed.** The boot procedure reads the boot sector of every drive via `_RDDRV` (`READ_BOOT_SEC`), which legitimately takes the quiet path in `BUILD_UPB` for a filesystem-less drive; `VAL_FIB` then called `SET_TIMEOUT`, and since `UD_TIME` never decays below 2, every later validation took a shortcut (the fixed/locked fast path or the media-check path) and returned success over an empty UPB — directory searches then found nothing. A new `HAS_UPB` helper (checks the FAT12/FAT16 flags in `UD_FLAGS`, which every real UPB sets) now gates those two shortcuts, forcing a new `BUILD_UPB` (and thus a proper "Not a DOS disk" disk error) for file operations. The B=2 fast path used by `_RDDRV`/`_WRDRV` is intentionally not gated, preserving raw sector access to non-FAT disks (and the boot flow) unchanged.

### DOS 1 mode fixes (`bank4/partit.mac`, `drv.mac`, `bank3/dos1ker.mac`)

* **`CHECK_MAP_IN_USE`, DOS 1 version**: unlike the DOS 2 version, it did not skip the entry of the drive being mapped, so a deferred drive's own device + FFFFFFFFh entry blocked its own re-assignment: the offline-removable fallback failed in `ASSIGN_PARTITION` and every access reported the generic error 12. It now skips the target entry (passed in IX by all its callers), same as the DOS 2 version.
* **`CONV_ERR`** (the driver error → DiskROM error code translation in the DOS 1 disk I/O path) now maps `.IDEVN` to "not ready" (code 2 → "Disk offline" in Disk BASIC). This entry exists to cover wrongly behaved drivers: a mapped drive always refers to a device declared by its driver, so `READ_WRITE` should never return "invalid device number" there, but drivers ported from Nextor 2 commonly return `.IDEVN` (formerly `.IDEVL`) for a device that exists but is currently absent, since Nextor 2 didn't distinguish that case from a nonexistent device. The correct driver behavior is returning `.NRDY` (the Sunrise IDE and Flashjacks drivers have been fixed accordingly, and the driver migration guide now documents the pitfall); DOS 2 mode already masks this driver defect in the media check layer (`mc_devcmd_err`).
* **`dos1ker.mac`**: comment-only addition documenting why the Disk BASIC error dispatch table (`T72C2`) covering only DiskROM codes 0-6 is sufficient (that handler is DOS 1 mode only; DOS 2 mode uses `DBERR`/`DERR_TAB` in bank 0).
* **`DIO_WR_LOOP`** (the page-1 write loop of the DOS 1 disk I/O handler in `drv.mac`) now routes disk errors through `CONV_ERR`, the same as the read loop; previously a multi-sector write involving page 1 returned the raw Nextor-style error code to the DiskROM caller instead of the classic doubled code.

### FDISK: committing the deletion of all partitions (`bank5/fdisk.c`, `Makefile`)

A new `partitionsDeletedFromDisk` state tracks that the device has partitions on disk but the in-memory list was emptied with "delete all partitions". In that state the W option becomes available as "Write empty partition table"; pressing it (after the usual data-destruction confirmation, worded "Remove all partitions") writes a master boot record with an empty partition table: an all-zeros sector with just the AA55h boot signature. Deliberately, this MBR does **not** begin with the x86-style dummy jump instruction that the partition-creating MBR carries: the boot process probes the first sector of each drive and takes a leading EBh/E9h byte as "this drive holds a boot sector", so a jump-headed empty MBR on a partition-less (deferred) drive would hijack the boot drive selection and prevent booting from later drives. Leaving the device with ESC while the deletion is uncommitted now asks for confirmation, the same as with uncommitted new partitions; the state is discarded on rescan.

While implementing this it turned out that the FDISK code segment budget (4120h up to `CHGBNK` at 7FD0h, 16048 bytes) is not checked anywhere: the `dd` that overlays `fdisk.dat` into the kernel base file silently truncates any excess, producing a broken FDISK with no build error. The Makefile now fails the build when the code segment (as reported by the linker map) exceeds the budget.

## Testing

Tested on blueMSX with the Sunrise IDE driver (blank master device, absent slave device, internal FDD), in both DOS 2 and DOS 1 modes:

* Boot mapping: A: attached to the master (no partition), B: reserved for the offline slave, C: mapped to the FDD.
* `FILES` on A: reports "Disk I/O error"; `FILES` on B: reports "Disk offline"; in both DOS modes.
* After partitioning the master with FDISK, A: becomes usable on the next access without rebooting.
