### PR TITLE
Miscellaneous fixes 4

### DIFF
--- a/sdk/C/includes/driver_device_queries.h
+++ b/sdk/C/includes/driver_device_queries.h
@@ -16,10 +16,11 @@
 #define DEVICE_QUERY_STOP_MOTOR         7  /* Stop the device motor */
 
 
-/* Sub-string codes for the GET_STRING query (passed in register B).
- * No asm-side counterpart yet - currently C-only. */
+/* Sub-string codes for the GET_STRING query (passed in register B). */
 
-#define STRING_MEDIUM_NAME 2
-#define STRING_DEVICE_NAME 4
+#define STRING_MANUFACTURER 1  /* Manufacturer name */
+#define STRING_MEDIUM_NAME  2  /* Medium name (obtained from the medium itself) */
+#define STRING_SERIAL_NUMBER 3 /* Serial number */
+#define STRING_DEVICE_NAME  4  /* Device name (provided by the driver) */
 
 #endif   //__DRIVER_DEVICE_QUERIES_H

--- a/sdk/asm/constants/driver_device_queries.inc
+++ b/sdk/asm/constants/driver_device_queries.inc
@@ -25,3 +25,10 @@
 	const	GET_FORMAT_CHOICES, 5	;Get format choices
 	const	DO_FORMAT,          6	;Format the device
 	const	STOP_MOTOR,         7	;Stop the device motor
+
+;Sub-string codes for the GET_STRING query (in register B).
+
+	const	STR_MANUFACTURER,   1	;Manufacturer name
+	const	STR_MEDIUM_NAME,    2	;Medium name (obtained from the medium itself)
+	const	STR_SERIAL_NUMBER,  3	;Serial number
+	const	STR_DEVICE_NAME,    4	;Device name (provided by the driver)

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -2641,12 +2641,17 @@ GDLI_DOS1:
 	or	a
 	jr	z,GDLI_D1_POP_RETOK
 
-	;--- Check if this is a ghost drive
+	;--- Check if this is a ghost drive.
+	;    The ghost state bits exist in FDD entries only: for other entries
+	;    the checked byte is part of the partition first absolute sector.
 
+	bit	6,(ix+UD1_RELATIVE_DRIVE##)
+	jr	z,GDLI_D1_NOGHOST
 	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##)
 	and	3
 	cp	2
 	jr	z,GDLI_D1_GHOST
+GDLI_D1_NOGHOST:
 
 	;--- Normal Nextor drive
 
@@ -4071,6 +4076,15 @@ GHOST_CLEANUP_DOS1:
 	ld	a,c
 	inc	a		;1-based
 	call	GET_KERNEX_ENTRY_HL
+
+	;The ghost state bits exist in FDD entries only: for other entries
+	;the checked byte is part of the partition first absolute sector
+	push	hl
+	ld	de,UD1_RELATIVE_DRIVE##
+	add	hl,de
+	bit	6,(hl)
+	pop	hl
+	ret	z		;Not a FDD drive: no ghost pair to clean up
 
 	;Check FAS byte 0 ghost state bits
 	push	hl

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -2574,15 +2574,19 @@ NOMNT:
 	ld	(iy+3),0FFh
 	ld	a,(ix+UD_DEVICE_NUMBER##)
 	ld	(iy+4),a
+	ld	(iy+5),1	;Fake LUN index, for Nextor 2 aware applications
+				;(the DOS 1 version of this routine does the same)
+
+	;Partition assignment pending: report a first sector number of -1
 
     bit UF_PAP,(ix+UD_DFLAGS##)
 	jr z,NOPAP
 
 	ld a,0FFh
-    ld	(ix+UD_FIRST_DEVICE_SECTOR##),a
-	ld	(ix+UD_FIRST_DEVICE_SECTOR##+1),a
-	ld	(ix+UD_FIRST_DEVICE_SECTOR##+2),a
-	ld	(ix+UD_FIRST_DEVICE_SECTOR##+3),a
+	ld	(iy+6),a
+	ld	(iy+7),a
+	ld	(iy+8),a
+	ld	(iy+9),a
 	cpl
 	ret
 

--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -897,8 +897,10 @@ AAD_MAX_DEVICE_NUM equ 17
 AAD_FALLBACK_DEVNUM equ 18 ;bit 7: removable, bit 6: floppy
 AAD_SAW_VALID_PART equ 19  ;Nonzero if the device currently being examined
                            ;holds at least one valid filesystem
+AAD_DEV_HAS_MAPPED equ 20  ;Nonzero if the device currently being examined
+                           ;has a valid partition already mapped to a drive
 
-AAD_SIZE equ 20
+AAD_SIZE equ 21
 
 AAFLAG_ENTER_EMU_MODE equ 0
 AAFLAG_IS_AUTOASPART equ 7
@@ -985,6 +987,7 @@ AUTO_NOEMU:
 	ld (ix+AAD_CURR_PART_DEVNUM),a
 	ld (ix+AAD_FALLBACK_DEVNUM),a
 	ld (ix+AAD_SAW_VALID_PART),a
+	ld (ix+AAD_DEV_HAS_MAPPED),a
 
 	jp AA_GET_DEVINFO
 
@@ -1002,6 +1005,7 @@ AA_DLOOP:
 	xor	a
 	ld	(ix+AAD_CURR_PART_DEVNUM),a
 	ld	(ix+AAD_SAW_VALID_PART),a
+	ld	(ix+AAD_DEV_HAS_MAPPED),a
 
 	;--- Note: earlier there was a device-level duplicate check here, 
 	;    but that's no longer needed: the drive-per-partition feature allows multiple
@@ -1327,7 +1331,7 @@ AA_SPC_OK:
 	call CHECK_MAP_IN_USE
 	pop iy
 	pop ix
-	jp nz,AA_PLOOP_NEXT
+	jp nz,AA_PART_IN_USE
 
 	;* All checks ok, partition is good.
     ;  If it has the active flag set, go ahead and assign it.
@@ -1366,6 +1370,14 @@ AA_NOT_ACTIVE:
 
     jp  AA_PLOOP_NEXT
 
+	;--- The partition is valid but already mapped to another drive:
+	;    remember that the device has already consumed at least one
+	;    of the drives reserved for it, then continue with the next partition
+
+AA_PART_IN_USE:
+	ld	(ix+AAD_DEV_HAS_MAPPED),1
+	jp	AA_PLOOP_NEXT
+
 	;--- The current device has been scanned completely (including the MBR
 	;    itself as a last resort) and no mappable partition was found on it.
 	;    If it doesn't hold any valid filesystem at all (not even one already
@@ -1379,6 +1391,22 @@ AA_NOT_ACTIVE:
 AA_DEV_EXHAUSTED:
 	bit	AAFLAG_IS_AUTOASPART,(ix+AAD_FLAGS)
 	jp	nz,AA_LLOOP_NEXT	;Fixed device requested: keep the "no suitable partition" error
+
+	;If a valid partition of this device is already mapped to another drive,
+	;the device has already consumed the drive(s) that GET_BOOT_DRIVES_COUNT
+	;reserved for it (one per active partition, minimum one): discard the
+	;candidate partition if it belongs to this device, so that the drive
+	;can be assigned to a device found later in the scan instead.
+
+	ld	a,(ix+AAD_DEV_HAS_MAPPED)
+	or	a
+	jr	z,AA_RECORD_FALLBACK
+	ld	a,(ix+AAD_CAND_PART_DEVNUM)
+	cp	(ix+AAD_CURR_PART_DEVNUM)
+	jp	nz,AA_LLOOP_NEXT	;Candidate is from another device: keep it
+	xor	a
+	ld	(ix+AAD_CAND_PART_DEVNUM),a
+	jp	AA_LLOOP_NEXT
 
 AA_RECORD_FALLBACK:
 	ld	a,(ix+AAD_SAW_VALID_PART)

--- a/source/tools/DEVINFO.MAC
+++ b/source/tools/DEVINFO.MAC
@@ -7,7 +7,7 @@ DEVINFO_STRLEN	equ	64
         ;        -------------------------------------------------------------------------------
 	db	13
 USAGE_S:
-	db	"DEVINFO v1.1- displays information about the devices handled by a disk driver",13,10
+	db	"DEVINFO v1.2 - displays information about the devices handled by a disk driver",13,10
 	db	13,10
 	db	"Usage: DEVINFO <slot>[-<subslot>][:<segment>]|0",13,10
 	db	13,10
@@ -83,7 +83,7 @@ DEV_LOOP:
 	;* Get and display manufacturer name
 
 GET_INFO_1:
-	ld	(iy+3),1
+	ld	(iy+3),DEVICE_QUERY.STR_MANUFACTURER##
 	call	CALL_DEV_QUERY
 	push	ix
 	pop	af
@@ -122,7 +122,7 @@ GET_INFO_1:
 	;* Get and display device name
 
 GET_INFO_2:
-	inc	(iy+3)
+	ld	(iy+3),DEVICE_QUERY.STR_DEVICE_NAME##
 	call	CALL_DEV_QUERY
 	push	ix
 	pop	af
@@ -138,19 +138,37 @@ GET_INFO_2:
 	ld	de,CRLF
 	ld	c,_ZSTROUT##
 	call	5
-	
-	;* Get and display serial number
 
-GET_INFO_3::
-	inc	(iy+3)
-	ld	hl,BUF_INFO
-	ld	(iy+6),l
-	ld	(iy+7),h
+	;* Get and display medium name
+	;  (only available when the driver can retrieve it from the medium itself)
+
+GET_INFO_3:
+	ld	(iy+3),DEVICE_QUERY.STR_MEDIUM_NAME##
 	call	CALL_DEV_QUERY
 	push	ix
 	pop	af
 	or	a
 	jr	nz,GET_INFO_4
+
+	ld	de,MEDIUM_MSG
+	ld	c,_ZSTROUT##
+	call	5
+	ld	hl,BUF_INFO
+	ld	bc,DEVINFO_STRLEN
+	call	PRPAD##
+	ld	de,CRLF
+	ld	c,_ZSTROUT##
+	call	5
+
+	;* Get and display serial number
+
+GET_INFO_4::
+	ld	(iy+3),DEVICE_QUERY.STR_SERIAL_NUMBER##
+	call	CALL_DEV_QUERY
+	push	ix
+	pop	af
+	or	a
+	jr	nz,GET_INFO_5
 
 
 	ld	de,SERIAL_MSG
@@ -163,7 +181,7 @@ GET_INFO_3::
 	ld	de,CRLF
 	ld	c,_ZSTROUT##
 	call	5
-GET_INFO_4:
+GET_INFO_5:
 
 	;--- Get and display device parameters
 
@@ -454,6 +472,8 @@ CRLF:
 
 NAME_MSG:
 	db	"  Device name: ",0
+MEDIUM_MSG:
+	db	"  Medium name: ",0
 MANUF_MSG:
 	db	"  Device manufacturer: ",0
 SERIAL_MSG:

--- a/source/tools/MAPDRV.MAC
+++ b/source/tools/MAPDRV.MAC
@@ -26,7 +26,7 @@ PT_EXT_LBA: equ 15
 	db	13,10
 	db	"<partition> can be any number starting at 1, or 0 to map the drive directly",13,10
 	db	"to the device (needed for partitionless devices such as floppy disks).",13,10
-	db	"Partition numbers 2 to 4 refer to extended partitions 2-1 to 2-4 if partition",13,10
+	db	"Partition numbers 2 to 4 refer to extended partitions 2-1 to 2-3 if partition",13,10
 	db	"2 of the device is extended, otherwise they refer to primary partitions.",13,10
         db	13,10
 	db	"<device> must be a number from 1 to 255.",13,10


### PR DESCRIPTION
This pull request fixes four defects:

* In the boot-time automatic drive mapping, a device could end up with more drives than the ones reserved for it by `GET_BOOT_DRIVES_COUNT` (one per active partition, with a minimum of one), stealing drives reserved for other devices.
* In DOS 1 mode, drives mapped to certain partitions were falsely detected as ghost drives, causing wrong `_GDLI` results (e.g. in `CALL DRVINFO`) and potential corruption of the drive mapping table when remapping.
* `DEVINFO.COM` displayed the medium name of each device labeled as the device name, and never displayed the actual device name.
* The DOS 2 version of `_GDLI` didn't return the documented "fake LUN index" value, and its "partition assignment pending" branch wrote to the unit descriptor instead of to the caller's buffer.

## Boot drive over-consumption

Reference scenario (same as in #212): a Sunrise IDE master device, an absent slave device (declared as removable by the driver), and an internal FDD. After creating two partitions on the master with only the first one flagged as active, both A: and B: got mapped to the master (partitions 1 and 2 respectively), and the slave got no drive at all (C: went to the FDD).

### The problem

While scanning devices for a drive that has no active partition to take, `AUTO_ASSIGN` records the first valid non-active partition found as the *candidate*, to be used if the whole scan ends without an active partition being assigned. That candidate recording didn't take into account whether the partition's device had already consumed the drive(s) reserved for it: in the reference scenario, when the scan for B: ran, the master's partition 1 was already mapped to A:, yet its non-active partition 2 was still recorded as candidate; and since #212 made candidates win over fallback devices regardless of device order, it beat the offline slave that B: was actually reserved for.

The defect predates #212 (two online devices where the first one holds an extra valid non-active partition would misassign the same way), but it was masked in the offline-slave scenario because offline removable devices used to be assigned immediately, cutting the scan short.

### The fix (`bank4/partit.mac`)

A new per-device flag ("device has a mapped partition", `AAD_DEV_HAS_MAPPED`) is set during the scan when a valid partition of the current device is found to be already mapped to another drive. When the scan of the device ends without an assignment, if the flag is set and the recorded candidate belongs to that same device, the candidate is discarded: the device has already consumed its reserved drive(s), so the drive being mapped can go to a device found later in the scan (or to a fallback device).

Notes:

* Devices with multiple active partitions still get one drive per active partition: active partitions are assigned immediately and are not affected by the new check.
* The `AUTO_ASPART` paths (the partition search performed on access to a drive that has no partition assigned, either because of a media change or because the boot mapping was deferred) deliberately keep their previous behavior: there the device is fixed, and "pick the next unmapped valid partition of this device" is exactly what's wanted.
* This makes the code match what the User Manual already stated ("one drive per active partition found in each device; if a device has no active partitions, it still gets one drive"); a clarifying sentence about the second (non-active) search pass has been added to the manual on the `update-docs-for-3.0` branch.

## DOS 1 mode: drives falsely detected as ghost drives (`bank4/partit.mac`)

In DOS 1 mode, the ghost drive state of a drive is encoded in bits 0-1 of the first byte of the "first absolute sector" field of its Nextor drives table entry — but only for FDD entries (bit 6 of the relative drive field set); for any other drive that byte is just the low byte of the partition's first absolute sector. Two routines checked the ghost state bits without checking the FDD flag first:

* `GDLI_DOS1` (the DOS 1 version of `_GDLI`): a drive mapped to a partition whose starting sector low byte has bits 0-1 = 10b was reported as a ghost drive of the previous drive (e.g. `CALL DRVINFO` said "Drive B: is assigned to: Ghost drive of A:" for a drive properly mapped to a hard disk partition).
* `GHOST_CLEANUP_DOS1` (run when a drive is remapped in DOS 1 mode): the same misdetection could cause actual corruption of the drives table: with a start sector low byte ending in bits 01b the routine treated the drive as a ghost master and unmapped the next drive; with bits 10b it cleared bits in the start sector of the drive itself and of its predecessor.

Both routines now check the FDD flag before looking at the ghost state bits (`DIO_ENTRY`, `MAYBE_CREATE_GHOST_DOS1` and `SETUP_GHOST_DOS1` already did it correctly).

## DEVINFO: wrong device name, and the medium name is now displayed (`tools/DEVINFO.MAC`)

The device query "get device information string" serves the manufacturer name as string 1, the medium name as string 2, the serial number as string 3, and the device name as string 4. `DEVINFO.COM` walked the string indexes with an `inc` from 1 to 3, so it requested string 2 and printed it under a "Device name" label: what it displayed as the device name was actually the medium name (the disk model string, in the case of the Sunrise IDE driver), and the real device name (string 4, the fixed name provided by the driver itself) was never displayed.

The tool now requests each string by its own index and displays, for every device: manufacturer, device name, medium name, serial number. Each line is printed only if the driver actually serves that string, so a device whose medium name isn't available (an empty card slot, a driver that doesn't implement the string) simply gets no "Medium name" line, in the same way the manufacturer and serial number lines were already conditional. The tool version has been bumped to 1.2.

To make this kind of mistake harder to repeat, the sub-string codes of the query have been added to the assembler SDK (`sdk/asm/constants/driver_device_queries.inc`), mirroring what `driver_device_queries.h` and `driver_driver_queries.inc` already do: `DEVICE_QUERY.STR_MANUFACTURER`, `STR_MEDIUM_NAME`, `STR_SERIAL_NUMBER` and `STR_DEVICE_NAME`. `DEVINFO.MAC` uses them by name now.

The description of the tool in the user manual has been updated accordingly on the `update-docs-for-3.0` branch.

## `_GDLI`: fake LUN index and pending partition assignment (`bank4/partit.mac`)

Two defects in the DOS 2 version of `F_GDLI`, both of them contradicting the routine's own header comment (and the Programmers Reference):

* Byte +5 of the returned buffer is documented as "always 1 for Nextor drivers" (it held the LUN index in Nextor 2, and the fixed 1 is kept so that Nextor 2 aware applications still see a valid value). The buffer is zeroed on entry and nothing ever wrote that byte, so it was always returned as 0. The DOS 1 version of the routine does write it ("set fake LUN index"), so the two versions disagreed as well; the DOS 2 version now writes it too.
* The "partition assignment pending" branch (`UF_PAP`) filled `UD_FIRST_DEVICE_SECTOR` in the unit descriptor with FFFFFFFFh instead of filling bytes +6..+9 of the caller's buffer, i.e. it wrote to `IX` where `IY` was meant. Besides not returning the intended value, this made a read-only query modify the unit descriptor. Fixed to write to the buffer.

Note that the second defect has no observable effect in the current kernel: `UF_PAP` is tested in three places and cleared in one, but it's never set anywhere, and drives attached to a device with no partition assigned report FFFFFFFFh anyway because that's what `AUTO_ASSIGN` stores in the unit descriptor. The fix is nevertheless worth having, since the branch would corrupt the reported information (and touch the unit descriptor) if the flag is ever used again.
