### PR TITLE
Update Docker image toolchain and add a test-publish option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,8 @@ jobs:
           sdcc -v
       - name: Install Nestor80
         env:
-          N80_VERSION: '1.3.5'
-          LK80_TAG: 'n80-v1.3.3-lk80-v1.1'
-          LK80_VERSION: '1.1.0'
+          N80_VERSION: '1.3.6'
+          LK80_VERSION: '1.1.1'
           LB80_VERSION: '1.0'
         run: |
           curl -Lo n80.zip https://github.com/Konamiman/Nestor80/releases/download/n80-v${N80_VERSION}/N80_${N80_VERSION}_SelfContained_linux-x64.zip
@@ -48,7 +47,7 @@ jobs:
           rm N80
           rm n80.zip
 
-          curl -Lo lk80.zip https://github.com/Konamiman/Nestor80/releases/download/${LK80_TAG}/LK80_${LK80_VERSION}_SelfContained_linux-x64.zip
+          curl -Lo lk80.zip https://github.com/Konamiman/Nestor80/releases/download/lk80-v${LK80_VERSION}/LK80_${LK80_VERSION}_SelfContained_linux-x64.zip
           unzip lk80.zip
           sudo install -v LK80 /usr/local/bin
           rm LK80

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,14 @@ on:
       - 'sdk/**'
       - 'buildtools/**'
       - '.github/workflows/**'
+      - 'docker/Dockerfile'   # defines the Nestor80 tool versions this job installs
   push:
     paths:
       - 'source/**'
       - 'sdk/**'
       - 'buildtools/**'
       - '.github/workflows/**'
+      - 'docker/Dockerfile'   # defines the Nestor80 tool versions this job installs
     branches:
       - 'v**'
     tags:
@@ -28,18 +30,34 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y binutils gcc make curl mtools zip
-          
+
+          # SDCC 4.2.0. This is the one toolchain version that is NOT read from
+          # docker/Dockerfile (see the next step): the Docker image installs
+          # Debian's "sdcc" apt package, whose version is whatever Debian ships
+          # (SDCC_VERSION in the Dockerfile is only a label), while this job
+          # needs a specific upstream tarball because the Ubuntu runner's apt
+          # package is a different version. Keep both at 4.2.0 by hand.
           curl -Lo sdcc.tar.bz2 https://sourceforge.net/projects/sdcc/files/sdcc-linux-amd64/4.2.0/sdcc-4.2.0-amd64-unknown-linux2.5.tar.bz2/download
           mkdir sdcc
           cd sdcc
           tar xjf ../sdcc.tar.bz2
           sudo cp -r sdcc-4.2.0/* /usr/local/
           sdcc -v
+      # The Nestor80 tool versions are defined ONCE, as the ARG defaults in
+      # docker/Dockerfile (the Docker image is the primary consumer). Read them
+      # from there so this job always builds with the same tools as the image.
+      - name: Read toolchain versions from docker/Dockerfile
+        run: |
+          for v in N80_VERSION LK80_VERSION LB80_VERSION; do
+            val="$(sed -nE "s/^ARG $v=(.+)$/\1/p" docker/Dockerfile)"
+            if [ -z "$val" ]; then
+              echo "::error::$v not found in docker/Dockerfile (expected a line 'ARG $v=<version>')" >&2
+              exit 1
+            fi
+            echo "$v=$val" >> "$GITHUB_ENV"
+            echo "$v=$val"
+          done
       - name: Install Nestor80
-        env:
-          N80_VERSION: '1.3.6'
-          LK80_VERSION: '1.1.1'
-          LB80_VERSION: '1.0'
         run: |
           curl -Lo n80.zip https://github.com/Konamiman/Nestor80/releases/download/n80-v${N80_VERSION}/N80_${N80_VERSION}_SelfContained_linux-x64.zip
           unzip n80.zip

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,12 @@ name: Publish image
 # the run fails unless you tick "overwrite". The moving tags (latest, major.minor,
 # exact version) are expected to advance on every publish and are not guarded.
 #
+# Tick "test" for a throwaway publish (e.g. trying a toolchain bump from a
+# branch before committing to a real revision): the ONLY tag pushed is
+# <version>-<rev>-test, nothing moves, the immutability guard is skipped so a
+# re-run simply overwrites the previous test image, and the baked-in image
+# revision reads "<rev>-test" so the image identifies itself as a test build.
+#
 # Multi-arch: builds and tests linux/amd64 and linux/arm64 (arm64 via QEMU on
 # the amd64 runner), then pushes a single manifest list.
 
@@ -29,6 +35,10 @@ on:
         description: "Overwrite if this revision (<version>-<rev>) is already published"
         type: boolean
         default: false
+      test:
+        description: "Test publish: push only <version>-<rev>-test (no moving tags, always overwrites; 'overwrite' is ignored)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -36,8 +46,9 @@ permissions:
 
 # Serialize publishes that share a revision, so two simultaneous runs can't both
 # pass the overwrite guard and race to corrupt the immutable <version>-<rev> tag.
+# Test publishes push a different tag, so they get their own group.
 concurrency:
-  group: publish-${{ github.repository }}-${{ inputs.revision }}
+  group: publish-${{ github.repository }}-${{ inputs.revision }}${{ inputs.test && '-test' || '' }}
   cancel-in-progress: false
 
 jobs:
@@ -51,6 +62,7 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
           REV: ${{ inputs.revision }}
+          TEST: ${{ inputs.test }}
         run: |
           set -eu
           if ! [[ "$REV" =~ ^r[0-9]+$ ]]; then
@@ -60,28 +72,38 @@ jobs:
           owner="$(printf '%s' "$OWNER" | tr 'A-Z' 'a-z')"   # GHCR requires lowercase
           image="ghcr.io/$owner/nextor-dev"
           ver="$(cat sdk/nextor-kernel-version.txt)"
-          pinned="$ver-$REV"
 
-          # Always: the exact version, plus the pinned <version>-<rev>.
-          tags="$ver $pinned"
-          # Moving tags only for a stable version. A prerelease carries a suffix
-          # (e.g. 3.0.0-beta1) and must not move latest / major.minor / major.
-          case "$ver" in
-            *-*) : ;;
-            *)
-              major="${ver%%.*}"; rest="${ver#*.}"; minor="${rest%%.*}"
-              tags="$tags $major.$minor $major latest"
-              ;;
-          esac
+          if [ "$TEST" = "true" ]; then
+            # Test publish: a single, freely overwritable tag; the image's own
+            # revision says "-test" too (manifest.json / labels).
+            imagerev="$REV-test"
+            pinned="$ver-$imagerev"
+            tags="$pinned"
+          else
+            imagerev="$REV"
+            pinned="$ver-$imagerev"
+            # Always: the exact version, plus the pinned <version>-<rev>.
+            tags="$ver $pinned"
+            # Moving tags only for a stable version. A prerelease carries a suffix
+            # (e.g. 3.0.0-beta1) and must not move latest / major.minor / major.
+            case "$ver" in
+              *-*) : ;;
+              *)
+                major="${ver%%.*}"; rest="${ver#*.}"; minor="${rest%%.*}"
+                tags="$tags $major.$minor $major latest"
+                ;;
+            esac
+          fi
 
           {
             echo "image=$image"
             echo "version=$ver"
+            echo "imagerev=$imagerev"
             echo "pinned=$pinned"
             echo "tags=$tags"
           } >> "$GITHUB_OUTPUT"
           echo "Image:   $image"
-          echo "Version: $ver (revision $REV)"
+          echo "Version: $ver (revision $imagerev)"
           echo "Tags:    $tags"
 
       - name: Log in to GHCR
@@ -93,8 +115,10 @@ jobs:
 
       # Fail fast (before the long build) if this exact revision is already
       # published and "overwrite" was not ticked. Only the immutable pinned tag
-      # is checked; the moving tags are meant to advance.
+      # is checked; the moving tags are meant to advance. Test publishes skip
+      # this entirely: their tag is meant to be overwritten.
       - name: Guard against overwriting an existing revision
+        if: ${{ !inputs.test }}
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
           PINNED: ${{ steps.meta.outputs.pinned }}
@@ -124,7 +148,7 @@ jobs:
       - name: Build and test each architecture
         env:
           VER: ${{ steps.meta.outputs.version }}
-          REV: ${{ inputs.revision }}
+          REV: ${{ steps.meta.outputs.imagerev }}
         run: |
           set -eu
           for arch in amd64 arm64; do
@@ -143,9 +167,10 @@ jobs:
       - name: Build and push multi-arch manifest
         env:
           VER: ${{ steps.meta.outputs.version }}
-          REV: ${{ inputs.revision }}
+          REV: ${{ steps.meta.outputs.imagerev }}
           IMAGE: ${{ steps.meta.outputs.image }}
           TAGS: ${{ steps.meta.outputs.tags }}
+          TEST: ${{ inputs.test }}
         run: |
           set -eu
           tagargs=""
@@ -157,6 +182,10 @@ jobs:
             --build-arg NEXTOR_IMAGE_REVISION="$REV" \
             $tagargs .
           {
-            echo "### Published \`$IMAGE\` (linux/amd64, linux/arm64)"
+            if [ "$TEST" = "true" ]; then
+              echo "### TEST publish of \`$IMAGE\` (linux/amd64, linux/arm64) - overwritable, not for general use"
+            else
+              echo "### Published \`$IMAGE\` (linux/amd64, linux/arm64)"
+            fi
             for t in $TAGS; do echo "- \`$IMAGE:$t\`"; done
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,15 +25,16 @@
 # per-target-arch.
 
 ARG DOTNET_TAG=8.0-bookworm-slim
-ARG N80_VERSION=1.3.5
-ARG LK80_TAG=n80-v1.3.3-lk80-v1.1
-ARG LK80_VERSION=1.1.0
+# Nestor80 release tags follow <tool>-v<version> (n80-v1.3.6, lk80-v1.1.1,
+# lb80-v1.0), so the download URLs are derived from the versions alone.
+ARG N80_VERSION=1.3.6
+ARG LK80_VERSION=1.1.1
 ARG LB80_VERSION=1.0
 ARG SDCC_VERSION=4.2.0
 ARG MKNEXROM_VERSION=1.2
 ARG NEXTOR_VERSION=unknown
 # Build revision: bumped when the toolchain changes but the kernel doesn't.
-# CI passes the real "rN"; local builds get "dev".
+# CI passes the real "rN" ("rN-test" for a test publish); local builds get "dev".
 ARG NEXTOR_IMAGE_REVISION=dev
 
 # ---------------------------------------------------------------------------
@@ -41,7 +42,7 @@ ARG NEXTOR_IMAGE_REVISION=dev
 # architecture-independent kernel base files, shared by every target image.
 # ---------------------------------------------------------------------------
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/runtime:${DOTNET_TAG} AS kernelbuild
-ARG N80_VERSION LK80_TAG LK80_VERSION LB80_VERSION BUILDARCH
+ARG N80_VERSION LK80_VERSION LB80_VERSION BUILDARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates unzip make binutils sdcc \
@@ -57,7 +58,7 @@ RUN set -eux; \
     base=https://github.com/Konamiman/Nestor80/releases/download; \
     mkdir -p /opt/nextor/bin; \
     curl -fsSL --retry 3 -o /tmp/n80.zip  "$base/n80-v${N80_VERSION}/N80_${N80_VERSION}_FrameworkDependant_${rid}.zip"; \
-    curl -fsSL --retry 3 -o /tmp/lk80.zip "$base/${LK80_TAG}/LK80_${LK80_VERSION}_FrameworkDependant_${rid}.zip"; \
+    curl -fsSL --retry 3 -o /tmp/lk80.zip "$base/lk80-v${LK80_VERSION}/LK80_${LK80_VERSION}_FrameworkDependant_${rid}.zip"; \
     curl -fsSL --retry 3 -o /tmp/lb80.zip "$base/lb80-v${LB80_VERSION}/LB80_${LB80_VERSION}_FrameworkDependant_${rid}.zip"; \
     unzip -o -j /tmp/n80.zip  N80  -d /opt/nextor/bin; \
     unzip -o -j /tmp/lk80.zip LK80 -d /opt/nextor/bin; \
@@ -91,7 +92,7 @@ RUN set -eux; \
 # the target-arch Nestor80 binaries and a target-arch mknexrom.
 # ---------------------------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_TAG} AS tools
-ARG N80_VERSION LK80_TAG LK80_VERSION LB80_VERSION TARGETARCH
+ARG N80_VERSION LK80_VERSION LB80_VERSION TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates unzip gcc libc6-dev \
@@ -106,7 +107,7 @@ RUN set -eux; \
     base=https://github.com/Konamiman/Nestor80/releases/download; \
     mkdir -p /opt/nextor/bin; \
     curl -fsSL --retry 3 -o /tmp/n80.zip  "$base/n80-v${N80_VERSION}/N80_${N80_VERSION}_FrameworkDependant_${rid}.zip"; \
-    curl -fsSL --retry 3 -o /tmp/lk80.zip "$base/${LK80_TAG}/LK80_${LK80_VERSION}_FrameworkDependant_${rid}.zip"; \
+    curl -fsSL --retry 3 -o /tmp/lk80.zip "$base/lk80-v${LK80_VERSION}/LK80_${LK80_VERSION}_FrameworkDependant_${rid}.zip"; \
     curl -fsSL --retry 3 -o /tmp/lb80.zip "$base/lb80-v${LB80_VERSION}/LB80_${LB80_VERSION}_FrameworkDependant_${rid}.zip"; \
     unzip -o -j /tmp/n80.zip  N80  -d /opt/nextor/bin; \
     unzip -o -j /tmp/lk80.zip LK80 -d /opt/nextor/bin; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,9 @@
 ARG DOTNET_TAG=8.0-bookworm-slim
 # Nestor80 release tags follow <tool>-v<version> (n80-v1.3.6, lk80-v1.1.1,
 # lb80-v1.0), so the download URLs are derived from the versions alone.
+# These three lines are the single source of truth for the Nestor80 versions:
+# .github/workflows/ci.yaml parses them (expects exactly "ARG NAME=value"), so
+# keep that form. SDCC is the exception -- see the comment in ci.yaml.
 ARG N80_VERSION=1.3.6
 ARG LK80_VERSION=1.1.1
 ARG LB80_VERSION=1.0

--- a/docker/README.md
+++ b/docker/README.md
@@ -355,7 +355,7 @@ Use the wrapper (runnable from anywhere - it locates the repo itself):
 ```sh
 docker/build.sh                       # tags 'nextor-dev'
 docker/build.sh -t my-nextor:test     # pass your own tag and/or build flags
-docker/build.sh --no-cache --build-arg N80_VERSION=1.3.6
+docker/build.sh --no-cache --build-arg N80_VERSION=1.3.7
 ```
 
 **Note:** `docker/build.sh` builds a **single-arch** image for your host (handy for local work). The multi-arch (amd64 + arm64) build lives in the publish workflow - see *Publishing*.
@@ -380,14 +380,16 @@ Override with `--build-arg NAME=value`:
 |---|---|---|
 | `NEXTOR_VERSION` | `unknown` | kernel version stamped into the image |
 | `NEXTOR_IMAGE_REVISION` | `dev` | image build revision (`rN`); CI sets the real value |
-| `N80_VERSION` | `1.3.5` | Nestor80 assembler release |
-| `LK80_VERSION` / `LK80_TAG` | `1.1.0` / `n80-v1.3.3-lk80-v1.1` | linker release + its GitHub tag |
-| `LB80_VERSION` | `1.0` | librarian release |
+| `N80_VERSION` | `1.3.6` | Nestor80 assembler release |
+| `LK80_VERSION` | `1.1.1` | Linkstor80 linker release |
+| `LB80_VERSION` | `1.0` | Libstor80 library manager release |
 | `SDCC_VERSION` | `4.2.0` | recorded in the manifest/labels; `sdcc` itself comes from Debian apt (also 4.2.0), so this only relabels |
 | `MKNEXROM_VERSION` | `1.2` | recorded in the manifest; `mknexrom` is compiled from source |
 | `DOTNET_TAG` | `8.0-bookworm-slim` | `dotnet/runtime` base image tag |
 
-Bumping a tool is a one-line change, e.g. `--build-arg N80_VERSION=1.3.6`; the new version automatically flows into `manifest.json` and the labels. (`sdcc` is the apt package, so `SDCC_VERSION` only changes the recorded label, not the installed compiler.)
+The three Nestor80 tools are fetched from GitHub releases tagged `<tool>-v<version>` (`n80-v1.3.6`, `lk80-v1.1.1`, `lb80-v1.0`), so the version alone determines the download.
+
+Bumping a tool is a one-line change, e.g. `--build-arg N80_VERSION=1.3.7`; the new version automatically flows into `manifest.json` and the labels. (`sdcc` is the apt package, so `SDCC_VERSION` only changes the recorded label, not the installed compiler.)
 
 ---
 
@@ -434,6 +436,8 @@ The official publish is the **`Publish image`** workflow (`.github/workflows/pub
 
 To avoid corrupting a build, the run **fails if the pinned `<version>-<rev>` tag already exists** unless you tick the **overwrite** checkbox, so re-running with the same revision is a deliberate choice, while bumping the revision (or moving the always-advancing `latest` / `major.minor` tags) is unaffected.
 
+For a throwaway build - say, trying a toolchain bump from a branch before committing to a real revision - tick the **test** checkbox. The run then pushes **only** `<version>-<rev>-test` (e.g. `3.0.0-beta1-r2-test`): no moving tags are touched, the immutability guard is skipped so a re-run simply overwrites the previous test image, and the baked-in image revision (`manifest.json`, labels) reads `r2-test` so the image identifies itself as a test build. Note that the workflow builds whatever branch or tag you select in the *Run workflow* dialog, so this is how to publish from a feature branch.
+
 **Note:** The first publish creates a **private** package; flip it to public once in the package's settings on GitHub if others should be able to pull it.
 
 ### The manual way
@@ -465,8 +469,8 @@ The advertised tag is the **kernel version**; image-only changes (a tool bump) r
 | `3.0.0` | an exact kernel version (moves to the newest revision of that kernel) |
 | `3.0` | newest `3.0.x` |
 | `latest` | newest stable |
-| `edge` | latest build from the development branch, no promises |
 | `3.0.0-r2` | a specific image revision (the kernel base files are byte-identical across `-rN` of the same kernel; only tools differ) |
+| `3.0.0-r2-test` | a throwaway test publish (workflow run with **test** ticked); freely overwritten, never referenced by a moving tag |
 
 Every component version is recorded in `manifest.json` and in OCI labels, so a moving tag is still fully traceable:
 


### PR DESCRIPTION
- Bump N80 to 1.3.6 and LK80 to 1.1.1 (mknexrom 1.2 already in place).
- Drop the LK80_TAG build arg: LK80 now has its own lk80-v<version>
  release tag like N80 and LB80, so the download URL is derived from the version alone.
- Publish workflow: add a "test" input that pushes only <version>-<rev>-test, skips the overwrite guard, and bakes "rN-test" as the image revision, for throwaway builds from a branch.
- README: update the build-args table, document the test option, and remove the "edge" tag that no workflow produces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional test publishing mode with overwriteable `-test` image tags.
  * Test and regular publishes now run independently and are clearly identified.
* **Improvements**
  * Simplified LK80 release version configuration for more consistent builds.
  * Updated Nestor80 and LK80 tool versions for builds.
* **Documentation**
  * Documented test publishing behavior and the updated image tagging scheme.
  * Removed the deprecated `edge` tag from the documented tag scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->