### PR TITLE
Improvements in makefiles

### DIFF
--- a/source/commandcom/Makefile
+++ b/source/commandcom/Makefile
@@ -35,20 +35,28 @@ commandcom: $(BIN_TOOLS)/COMMAND3.COM
 
 # The bin/tools copy is a target of its own (not a side effect of the link
 # recipe), so it gets re-created when bin/tools is missing or empty even if
-# the COMMAND3.COM in this directory is up to date.
-$(BIN_TOOLS)/COMMAND3.COM: COMMAND3.COM
+# the COMMAND3.COM in this directory is up to date. The directory itself is
+# an order-only prerequisite: it gets created on demand, but its timestamp
+# changes never trigger a re-copy.
+$(BIN_TOOLS)/COMMAND3.COM: COMMAND3.COM | $(BIN_TOOLS)
 	cp $< $@
 
-.PHONY: commandcom prerequisites clean
+$(BIN_TOOLS):
+	@mkdir -p $@
+
+.PHONY: commandcom clean
 
 TOOLS := N80 LK80
 
-prerequisites:
-	@mkdir -p $(BIN_TOOLS)
-	$(foreach exec,$(TOOLS),\
-		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
-
--include prerequisites
+# Check that the required tools are available. This is done at parse time
+# (not in a recipe) so that it runs before anything else regardless of the
+# make version: the former "-include prerequisites" trick relied on make
+# running a phony target's recipe at startup, which GNU make 4.4+ no longer
+# does. Skipped when just cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+$(foreach exec,$(TOOLS),\
+	$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
+endif
 
 # The link order must match the physical layout of the program.
 # COMMAND3.COM is a dual-language binary: it carries both the English

--- a/source/commandcom/Makefile
+++ b/source/commandcom/Makefile
@@ -19,9 +19,7 @@ endif
 
 export LK80_ARGS=--no-show-banner --verbosity 0 --output-file-case lower --output-format bin
 
-define copy_to_bin
-	cp $(1) ../../bin/tools/$(2)
-endef
+BIN_TOOLS := ../../bin/tools
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
@@ -33,14 +31,20 @@ define assemble_as
 	@$(N80) $(1) $(2) $(3)
 endef
 
-commandcom: COMMAND3.COM
+commandcom: $(BIN_TOOLS)/COMMAND3.COM
+
+# The bin/tools copy is a target of its own (not a side effect of the link
+# recipe), so it gets re-created when bin/tools is missing or empty even if
+# the COMMAND3.COM in this directory is up to date.
+$(BIN_TOOLS)/COMMAND3.COM: COMMAND3.COM
+	cp $< $@
 
 .PHONY: commandcom prerequisites clean
 
 TOOLS := N80 LK80
 
 prerequisites:
-	@mkdir -p ../../bin/tools
+	@mkdir -p $(BIN_TOOLS)
 	$(foreach exec,$(TOOLS),\
 		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
 
@@ -82,7 +86,6 @@ COMMAND3.COM: \
 
 	@$(LK80) --output-file COMMAND3.COM --code 0100h $(SDK_RELS) $(RELS)
 	$(call check_size,COMMAND3.COM)
-	$(call copy_to_bin,COMMAND3.COM)
 
 .SECONDEXPANSION:
 $(RELS): \

--- a/source/drivers/Makefile
+++ b/source/drivers/Makefile
@@ -81,7 +81,7 @@ endif
 
 UNDOC_MODE_STAMP := $(BIN_DRIVERS)/.build-variant$(if $(_VARIANT_SUFFIX),$(_VARIANT_SUFFIX),.default)
 
-$(UNDOC_MODE_STAMP):
+$(UNDOC_MODE_STAMP): | $(BIN_DRIVERS)
 	@rm -f $(BIN_DRIVERS)/.build-variant*
 	@touch $@
 
@@ -150,14 +150,22 @@ everything:
 
 TOOLS := $(N80) $(MKNEXROM) dd cat
 
-.PHONY: prerequisites
-
-prerequisites:
-	@mkdir -p $(BIN_KERNEL_BASE) $(BIN_DRIVERS)
-	$(foreach exec,$(TOOLS),\
+# Check that the required tools are available. This is done at parse time
+# (not in a recipe) so that it runs before anything else regardless of the
+# make version: the former "-include prerequisites" trick relied on make
+# running a phony target's recipe at startup, which GNU make 4.4+ no longer
+# does. Skipped when just cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+$(foreach exec,$(TOOLS),\
         $(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
+endif
 
--include prerequisites
+# The output directories are created on demand: every rule that writes
+# into one of them lists it as an order-only prerequisite, so that it
+# exists before the recipe runs but its timestamp changes never trigger
+# rebuilds.
+$(BIN_DRIVERS) $(BIN_KERNEL_BASE):
+	@mkdir -p $@
 
 
 ########################
@@ -189,7 +197,7 @@ base: $(LOCAL_BASE)
 	    INVERT_CTRL=$(INVERT_CTRL) \
 	    INVERT_KANJI=$(INVERT_KANJI)
 
-$(LOCAL_BASE): ../kernel/nextor_base.dat
+$(LOCAL_BASE): ../kernel/nextor_base.dat | $(BIN_KERNEL_BASE)
 	cp ../kernel/nextor_base.dat $@
 
 NEXTOR_BASE := $(LOCAL_BASE)
@@ -214,19 +222,22 @@ ascii16: $(ROM_ASCII16)
 
 $(BIN_DRIVERS)/standalone-rom-driver.bin: \
 	$(UNDOC_MODE_STAMP) \
-	standalone-rom-driver.asm
+	standalone-rom-driver.asm \
+	| $(BIN_DRIVERS)
 
 	$(call assemble,standalone-rom-driver.asm,--build-type abs --output-file-extension bin)
 
 $(BIN_DRIVERS)/chgbnk-ascii8.bin: \
 	$(UNDOC_MODE_STAMP) \
-	chgbnk-ascii8.asm
+	chgbnk-ascii8.asm \
+	| $(BIN_DRIVERS)
 
 	$(call assemble,chgbnk-ascii8.asm,--build-type abs --output-file-extension bin)
 
 $(BIN_DRIVERS)/chgbnk-ascii16.bin: \
 	$(UNDOC_MODE_STAMP) \
-	chgbnk-ascii16.asm
+	chgbnk-ascii16.asm \
+	| $(BIN_DRIVERS)
 
 	$(call assemble,chgbnk-ascii16.asm,--build-type abs --output-file-extension bin)
 
@@ -236,21 +247,24 @@ $(BIN_DRIVERS)/chgbnk-ascii16.bin: \
 
 $(BIN_DRIVERS)/_standalone-rom-driver.bin: \
 	$(BIN_DRIVERS)/standalone-rom-driver.bin \
-	$(BIN_DRIVERS)/256.bytes
+	$(BIN_DRIVERS)/256.bytes \
+	| $(BIN_DRIVERS)
 
 	cat $(BIN_DRIVERS)/256.bytes $(BIN_DRIVERS)/standalone-rom-driver.bin > $@
 
 $(ROM_ASCII8): \
 	$(NEXTOR_BASE) \
 	$(BIN_DRIVERS)/_standalone-rom-driver.bin \
-	$(BIN_DRIVERS)/chgbnk-ascii8.bin
+	$(BIN_DRIVERS)/chgbnk-ascii8.bin \
+	| $(BIN_DRIVERS)
 
 	$(call mknexrom_rom,$@,$(BIN_DRIVERS)/_standalone-rom-driver.bin,$(BIN_DRIVERS)/chgbnk-ascii8.bin)
 
 $(ROM_ASCII16): \
 	$(NEXTOR_BASE) \
 	$(BIN_DRIVERS)/_standalone-rom-driver.bin \
-	$(BIN_DRIVERS)/chgbnk-ascii16.bin
+	$(BIN_DRIVERS)/chgbnk-ascii16.bin \
+	| $(BIN_DRIVERS)
 
 	$(call mknexrom_rom,$@,$(BIN_DRIVERS)/_standalone-rom-driver.bin,$(BIN_DRIVERS)/chgbnk-ascii16.bin)
 
@@ -265,7 +279,8 @@ ram-example: $(BIN_DRIVERS)/ram-driver-example.drv
 
 $(BIN_DRIVERS)/ram-driver-example.drv: \
 	$(UNDOC_MODE_STAMP) \
-	ram-driver-example.asm
+	ram-driver-example.asm \
+	| $(BIN_DRIVERS)
 
 	$(call assemble,ram-driver-example.asm,--build-type abs --output-file-extension drv)
 
@@ -274,7 +289,7 @@ $(BIN_DRIVERS)/ram-driver-example.drv: \
 ###  COMMON          ###
 ########################
 
-$(BIN_DRIVERS)/256.bytes:
+$(BIN_DRIVERS)/256.bytes: | $(BIN_DRIVERS)
 	dd if=/dev/zero of=$@ bs=1 count=256
 
 clean:

--- a/source/drivers/Makefile
+++ b/source/drivers/Makefile
@@ -160,11 +160,10 @@ $(foreach exec,$(TOOLS),\
         $(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
 endif
 
-# The output directories are created on demand: every rule that writes
-# into one of them lists it as an order-only prerequisite, so that it
-# exists before the recipe runs but its timestamp changes never trigger
-# rebuilds.
-$(BIN_DRIVERS) $(BIN_KERNEL_BASE):
+# The output directory is created on demand: every rule that writes into
+# it lists it as an order-only prerequisite, so that it exists before the
+# recipe runs but its timestamp changes never trigger rebuilds.
+$(BIN_DRIVERS):
 	@mkdir -p $@
 
 
@@ -173,11 +172,8 @@ $(BIN_DRIVERS) $(BIN_KERNEL_BASE):
 ########################
 
 # Path to the kernel base file used as input by MKNEXROM. If NEXTOR_BASE
-# is set, use it as-is. Otherwise build it via the kernel Makefile and
-# publish a variant-named copy to bin/kernel-base (the same file the
-# kernel makefile itself publishes; recreating it here keeps the build
-# working after bin/ has been wiped while ../kernel/nextor_base.dat is
-# still up to date).
+# is set, use it as-is. Otherwise build it via the kernel Makefile, whose
+# `base` target publishes the variant-named copy to bin/kernel-base.
 
 ifeq ($(strip $(NEXTOR_BASE)),)
 
@@ -186,19 +182,15 @@ LOCAL_BASE := $(BIN_KERNEL_BASE)/Nextor-$(NEXTOR_KERNEL_VERSION).base$(_VARIANT_
 base: $(LOCAL_BASE)
 
 # Always re-invoke the kernel sub-make so source/kernel changes are
-# picked up. The sub-make is incremental and only touches
-# ../kernel/nextor_base.dat if something there actually changed; that
-# file's mtime drives whether $(LOCAL_BASE) (and the ROMs that depend
-# on it) need to rebuild.
-../kernel/nextor_base.dat: FORCE
+# picked up. The sub-make is incremental and only touches $(LOCAL_BASE)
+# if something there actually changed; that file's mtime drives whether
+# the ROMs that depend on it need to rebuild.
+$(LOCAL_BASE): FORCE
 	@$(MAKE) --no-print-directory -C ../kernel base \
 	    NO_UNDOC_CPU_INSTRUCTIONS=$(NO_UNDOC_CPU_INSTRUCTIONS) \
 	    INVERT_SHIFT=$(INVERT_SHIFT) \
 	    INVERT_CTRL=$(INVERT_CTRL) \
 	    INVERT_KANJI=$(INVERT_KANJI)
-
-$(LOCAL_BASE): ../kernel/nextor_base.dat | $(BIN_KERNEL_BASE)
-	cp ../kernel/nextor_base.dat $@
 
 NEXTOR_BASE := $(LOCAL_BASE)
 

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -132,6 +132,8 @@ endef
 ###  MAIN RULE  ###
 ###################
 
+.PHONY: all base
+
 all: base ../../sdk/nextor-kernel-version.txt
 
 # `everything` builds the kernel base file across all twelve variant

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -108,8 +108,10 @@ define hex2bin
     objcopy -I ihex -O binary $(1) $(2)
 endef
 
+BIN_KERNEL_BASE := ../../bin/kernel-base
+
 define copy_to_bin
-	cp $(1) ../../bin/kernel-base/$(2)
+	cp $(1) $(BIN_KERNEL_BASE)/$(2)
 endef
 
 define assemble
@@ -172,14 +174,22 @@ everything:
 
 TOOLS := $(N80) $(LK80) $(LB80) objcopy sdcc dd
 
-.PHONY: prerequisites
-
-prerequisites:
-	@mkdir -p ../../bin/kernel-base
-	$(foreach exec,$(TOOLS),\
+# Check that the required tools are available. This is done at parse time
+# (not in a recipe) so that it runs before anything else regardless of the
+# make version: the former "-include prerequisites" trick relied on make
+# running a phony target's recipe at startup, which GNU make 4.4+ no longer
+# does. Skipped when just cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+$(foreach exec,$(TOOLS),\
         $(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
+endif
 
--include prerequisites
+# bin/kernel-base, where the generated base file is published, is created
+# on demand: it is an order-only prerequisite of nextor_base.dat, so that
+# it exists before the copy but its timestamp changes never trigger a
+# rebuild.
+$(BIN_KERNEL_BASE):
+	@mkdir -p $@
 
 
 base: nextor_base.dat
@@ -205,7 +215,8 @@ nextor_base.dat: \
 	bank4/B4.BIN \
 	bank5/B5.BIN \
 	bank5/fdisk.dat \
-	bank6/B6.BIN
+	bank6/B6.BIN \
+	| $(BIN_KERNEL_BASE)
 
 	@for f in bank0/B0.BIN bank3/B3.BIN; do \
 		sz=$$(stat -c '%s' $$f); \

--- a/source/kernel/Makefile
+++ b/source/kernel/Makefile
@@ -108,11 +108,10 @@ define hex2bin
     objcopy -I ihex -O binary $(1) $(2)
 endef
 
+# The generated kernel base file is published to bin/kernel-base under a
+# name that encodes the kernel version and the build variant.
 BIN_KERNEL_BASE := ../../bin/kernel-base
-
-define copy_to_bin
-	cp $(1) $(BIN_KERNEL_BASE)/$(2)
-endef
+PUBLISHED_BASE := $(BIN_KERNEL_BASE)/Nextor-$(NEXTOR_KERNEL_VERSION).base$(_VARIANT_SUFFIX).dat
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
@@ -184,15 +183,18 @@ $(foreach exec,$(TOOLS),\
         $(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
 endif
 
-# bin/kernel-base, where the generated base file is published, is created
-# on demand: it is an order-only prerequisite of nextor_base.dat, so that
-# it exists before the copy but its timestamp changes never trigger a
-# rebuild.
+base: $(PUBLISHED_BASE)
+
+# The published copy is a target of its own (not a side effect of the
+# nextor_base.dat recipe), so it gets re-created when bin/kernel-base is
+# missing or empty even if nextor_base.dat is up to date. The directory
+# itself is an order-only prerequisite: it gets created on demand, but its
+# timestamp changes never trigger a re-copy.
+$(PUBLISHED_BASE): nextor_base.dat | $(BIN_KERNEL_BASE)
+	cp $< $@
+
 $(BIN_KERNEL_BASE):
 	@mkdir -p $@
-
-
-base: nextor_base.dat
 
 # Publish the digested kernel version into the SDK, so driver developers (and
 # their makefiles) can read it without building anything or using Docker.
@@ -215,8 +217,7 @@ nextor_base.dat: \
 	bank4/B4.BIN \
 	bank5/B5.BIN \
 	bank5/fdisk.dat \
-	bank6/B6.BIN \
-	| $(BIN_KERNEL_BASE)
+	bank6/B6.BIN
 
 	@for f in bank0/B0.BIN bank3/B3.BIN; do \
 		sz=$$(stat -c '%s' $$f); \
@@ -239,8 +240,6 @@ nextor_base.dat: \
 	dd conv=notrunc if=doshead.BIN of=nextor_base.dat bs=1 count=255 seek=80k
 	dd conv=notrunc if=doshead.BIN of=nextor_base.dat bs=1 count=255 seek=96k
 	dd conv=notrunc if=bank5/fdisk.dat of=nextor_base.dat bs=1 count=16048 seek=82176
-
-	$(call copy_to_bin,nextor_base.dat,Nextor-$(NEXTOR_KERNEL_VERSION).base$(_VARIANT_SUFFIX).dat)
 
 255.bytes:
 	dd if=/dev/zero of=255.bytes bs=1 count=255

--- a/source/nextor_sys/Makefile
+++ b/source/nextor_sys/Makefile
@@ -18,9 +18,7 @@ export LK80_ARGS=--no-show-banner --verbosity 0 --output-file-case lower --outpu
 # NO_UNDOC_CPU_INSTRUCTIONS build flag (see sdk/asm/macros/undoc.inc)
 # has no effect here and is intentionally not plumbed through.
 
-define copy_to_bin
-	cp $(1) ../../bin/tools/$(2)
-endef
+BIN_TOOLS := ../../bin/tools
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
@@ -32,14 +30,23 @@ define assemble_as
 	@$(N80) $(1) $(2) $(3)
 endef
 
-nextor-sys: NEXTOR.SYS NEXTOR.SYS.japanese
+SYS_FILES := NEXTOR.SYS NEXTOR.SYS.japanese
+BIN_SYS_FILES := $(addprefix $(BIN_TOOLS)/,$(SYS_FILES))
+
+nextor-sys: $(BIN_SYS_FILES)
+
+# The bin/tools copies are targets of their own (not a side effect of the
+# link recipes), so they get re-created when bin/tools is missing or empty
+# even if the linked files in this directory are up to date.
+$(BIN_SYS_FILES): $(BIN_TOOLS)/%: %
+	cp $< $@
 
 .PHONY: nextor-sys prerequisites
 
 TOOLS := N80 LK80
 
 prerequisites:
-	@mkdir -p ../../bin/tools
+	@mkdir -p $(BIN_TOOLS)
 	$(foreach exec,$(TOOLS),\
 		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
 
@@ -57,7 +64,6 @@ NEXTOR.SYS: \
 	sys.rel
 
 	@$(LK80) --output-file NEXTOR.SYS --code 0100h $(SDK_RELS) data.rel reloc.rel ver.rel ref.rel sys.rel real.rel sys.rel messages.rel end.rel
-	$(call copy_to_bin,NEXTOR.SYS)
 
 NEXTOR.SYS.japanese: \
 	$(JRELS) \
@@ -66,7 +72,6 @@ NEXTOR.SYS.japanese: \
 	sysj.rel
 
 	@$(LK80) --output-file NEXTOR.SYS.japanese --code 0100h $(SDK_RELS) data.rel reloc.rel ver.rel ref.rel sysj.rel real.rel sysj.rel messages.rel kmsg.rel end.rel
-	$(call copy_to_bin,NEXTOR.SYS.japanese)
 
 # sys.mac is assembled twice, once per NEXTOR.SYS variant, so each variant
 # gets its own distinctly named .rel file. Assembling to a shared sys.rel

--- a/source/nextor_sys/Makefile
+++ b/source/nextor_sys/Makefile
@@ -37,20 +37,28 @@ nextor-sys: $(BIN_SYS_FILES)
 
 # The bin/tools copies are targets of their own (not a side effect of the
 # link recipes), so they get re-created when bin/tools is missing or empty
-# even if the linked files in this directory are up to date.
-$(BIN_SYS_FILES): $(BIN_TOOLS)/%: %
+# even if the linked files in this directory are up to date. The directory
+# itself is an order-only prerequisite: it gets created on demand, but its
+# timestamp changes never trigger a re-copy.
+$(BIN_SYS_FILES): $(BIN_TOOLS)/%: % | $(BIN_TOOLS)
 	cp $< $@
 
-.PHONY: nextor-sys prerequisites
+$(BIN_TOOLS):
+	@mkdir -p $@
+
+.PHONY: nextor-sys
 
 TOOLS := N80 LK80
 
-prerequisites:
-	@mkdir -p $(BIN_TOOLS)
-	$(foreach exec,$(TOOLS),\
-		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
-
--include prerequisites
+# Check that the required tools are available. This is done at parse time
+# (not in a recipe) so that it runs before anything else regardless of the
+# make version: the former "-include prerequisites" trick relied on make
+# running a phony target's recipe at startup, which GNU make 4.4+ no longer
+# does. Skipped when just cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+$(foreach exec,$(TOOLS),\
+	$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
+endif
 
 INCS := ../kernel/macros.inc ../kernel/const.inc ../kernel/condasm.inc
 RELS := messages.rel real.rel ref.rel reloc.rel ver.rel end.rel

--- a/source/tools/C/Makefile
+++ b/source/tools/C/Makefile
@@ -31,24 +31,32 @@ c-tools: $(BIN_COMS)
 
 # The bin/tools copies are targets of their own (not a side effect of the
 # build recipes), so they get re-created when bin/tools is missing or empty
-# even if the .COM files in this directory are up to date.
+# even if the .COM files in this directory are up to date. The directory
+# itself is an order-only prerequisite: it gets created on demand, but its
+# timestamp changes never trigger a re-copy.
 # The trailing rm removes the lowercase-named copy that builds prior to the
 # uppercase renaming of the tools left in bin/tools, so that stale duplicates
 # don't end up in the tools disk image.
-$(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM
+$(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM | $(BIN_TOOLS)
 	cp $< $@
 	@rm -f $(BIN_TOOLS)/$(call lc,$<)
 
-.PHONY: c-tools prerequisites
+$(BIN_TOOLS):
+	@mkdir -p $@
+
+.PHONY: c-tools
 
 TOOLS := sdcc sdasz80 objcopy N80
 
-prerequisites:
-	@mkdir -p $(BIN_TOOLS)
-	$(foreach exec,$(TOOLS),\
-		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
-
--include prerequisites
+# Check that the required tools are available. This is done at parse time
+# (not in a recipe) so that it runs before anything else regardless of the
+# make version: the former "-include prerequisites" trick relied on make
+# running a phony target's recipe at startup, which GNU make 4.4+ no longer
+# does. Skipped when just cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+$(foreach exec,$(TOOLS),\
+	$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
+endif
 
 SDK_C_RELS := asmcall.rel printf.rel print_msxdos.rel strcmpi.rel
 

--- a/source/tools/C/Makefile
+++ b/source/tools/C/Makefile
@@ -15,9 +15,7 @@ define hex2bin
 	objcopy -I ihex -O binary $(1) $(2)
 endef
 
-define copy_to_bin
-	cp $(1) ../../../bin/tools/$(2)
-endef
+BIN_TOOLS := ../../../bin/tools
 
 lc = $(shell echo $(1) | tr A-Z a-z)
 
@@ -27,14 +25,26 @@ COMS := EMUFILE.COM FSIZE.COM NEXBOOT.COM VSFT.COM EPTCFT.COM DRVROP.COM DRVTEST
 # tables assembled with Nestor80), excluded from the generic rule.
 SPECIAL_COMS := DISKCOPY.COM XDIR.COM XCOPY.COM
 
-c-tools: $(COMS) $(SPECIAL_COMS)
+BIN_COMS := $(addprefix $(BIN_TOOLS)/,$(COMS) $(SPECIAL_COMS))
+
+c-tools: $(BIN_COMS)
+
+# The bin/tools copies are targets of their own (not a side effect of the
+# build recipes), so they get re-created when bin/tools is missing or empty
+# even if the .COM files in this directory are up to date.
+# The trailing rm removes the lowercase-named copy that builds prior to the
+# uppercase renaming of the tools left in bin/tools, so that stale duplicates
+# don't end up in the tools disk image.
+$(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM
+	cp $< $@
+	@rm -f $(BIN_TOOLS)/$(call lc,$<)
 
 .PHONY: c-tools prerequisites
 
 TOOLS := sdcc sdasz80 objcopy N80
 
 prerequisites:
-	@mkdir -p ../../../bin/tools
+	@mkdir -p $(BIN_TOOLS)
 	$(foreach exec,$(TOOLS),\
 		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
 
@@ -62,9 +72,6 @@ define check_header
 	fi
 endef
 
-# The trailing rm removes the lowercase-named copy that builds prior to the
-# uppercase renaming of the tools left in bin/tools, so that stale duplicates
-# don't end up in the tools disk image.
 .SECONDEXPANSION:
 $(COMS): \
 	$$(call lc,$$(patsubst %.COM,%.c,$$@)) \
@@ -74,8 +81,6 @@ $(COMS): \
 
 	sdcc --code-loc 0x180 --data-loc 0 -mz80 --disable-warning 196 --disable-warning 85 --no-std-crt0 -I../../../sdk/C/includes -I../../../sdk/C/code crt0_msxdos.rel $(SDK_C_RELS) $(call lc,$(patsubst %.COM,%.c,$@))
 	$(call hex2bin,$(call lc,$(patsubst %.COM,%.ihx,$@)),$@)
-	$(call copy_to_bin,$@)
-	@rm -f ../../../bin/tools/$(call lc,$@)
 
 crt0_msxdos.rel: \
 	../../../sdk/C/code/crt0_msxdos.asm
@@ -96,8 +101,6 @@ DISKCOPY.COM: \
 	$(call check_header,crt0_diskcopy.rel,0x480)
 	sdcc --code-loc 0x480 --data-loc 0 -mz80 --disable-warning 196 --disable-warning 85 --no-std-crt0 -I../../../sdk/C/includes -I../../../sdk/C/code crt0_diskcopy.rel $(SDK_C_RELS) diskcopy_msgs.rel diskcopy.c
 	$(call hex2bin,diskcopy.ihx,$@)
-	$(call copy_to_bin,$@)
-	@rm -f ../../../bin/tools/diskcopy.com
 
 crt0_diskcopy.rel: crt0_diskcopy.mac
 	sdasz80 -o crt0_diskcopy.rel crt0_diskcopy.mac
@@ -114,8 +117,6 @@ XDIR.COM: \
 	$(call check_header,crt0_xdir.rel,0x400)
 	sdcc --code-loc 0x400 --data-loc 0 -mz80 --disable-warning 196 --disable-warning 85 --no-std-crt0 -I../../../sdk/C/includes -I../../../sdk/C/code crt0_xdir.rel $(SDK_C_RELS) xdir_msgs.rel xdir.c
 	$(call hex2bin,xdir.ihx,$@)
-	$(call copy_to_bin,$@)
-	@rm -f ../../../bin/tools/xdir.com
 
 crt0_xdir.rel: crt0_xdir.mac
 	sdasz80 -o crt0_xdir.rel crt0_xdir.mac
@@ -132,8 +133,6 @@ XCOPY.COM: \
 	$(call check_header,crt0_xcopy.rel,0x600)
 	sdcc --code-loc 0x600 --data-loc 0 -mz80 --disable-warning 196 --disable-warning 85 --no-std-crt0 -I../../../sdk/C/includes -I../../../sdk/C/code crt0_xcopy.rel $(SDK_C_RELS) xcopy_msgs.rel xcopy.c
 	$(call hex2bin,xcopy.ihx,$@)
-	$(call copy_to_bin,$@)
-	@rm -f ../../../bin/tools/xcopy.com
 
 crt0_xcopy.rel: crt0_xcopy.mac
 	sdasz80 -o crt0_xcopy.rel crt0_xcopy.mac

--- a/source/tools/Makefile
+++ b/source/tools/Makefile
@@ -15,9 +15,7 @@ endif
 
 export LK80_ARGS=--no-show-banner --verbosity 0 --output-file-case lower --output-format bin --code-before-data
 
-define copy_to_bin
-	cp $(1) ../../bin/tools/$(2)
-endef
+BIN_TOOLS := ../../bin/tools
 
 define assemble
 	@printf "\n\033[0;36mAssembling %s\033[0m\n\n" $(1)
@@ -43,14 +41,22 @@ SHARED_NAMES := byte2asc extpar chk_nextor chkonoff chklet chklet_noterm prslot 
 SHARED_RELS  := $(foreach n,$(SHARED_NAMES),$(call uc,$(n)).REL)
 RELS := $(SDK_RELS) DATA.REL $(SHARED_RELS)
 
-asm-tools: $(COMS)
+BIN_COMS := $(addprefix $(BIN_TOOLS)/,$(COMS))
 
-.phony: prerequisites
+asm-tools: $(BIN_COMS)
+
+# The bin/tools copies are targets of their own (not a side effect of the
+# link recipes), so they get re-created when bin/tools is missing or empty
+# even if the .COM files in this directory are up to date.
+$(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM
+	cp $< $@
+
+.PHONY: prerequisites
 
 TOOLS := N80 LK80
 
 prerequisites:
-	@mkdir -p ../../bin/tools
+	@mkdir -p $(BIN_TOOLS)
 	$(foreach exec,$(TOOLS),\
 		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
 
@@ -66,7 +72,6 @@ $(GENERIC_COMS): \
 
 	$(call assemble,$(patsubst %.COM,%.MAC,$@),--define-symbols GENERATE_PUBLIC_SYMBOLS)
 	@$(LK80) --output-file $@ --code 0100h $(SDK_RELS) DATA.REL $(patsubst %.COM,%.REL,$@) $(SHARED_RELS)
-	$(call copy_to_bin,$@)
 
 # CHKDSK is self-contained (it carries its own Nextor version check instead
 # of using CHK_NEXTOR, since it must run on Nextor 2.1) and its runtime data
@@ -77,13 +82,11 @@ $(GENERIC_COMS): \
 CHKDSK.COM: CHKDSK.MAC $(SDK_RELS)
 	$(call assemble,CHKDSK.MAC)
 	@$(LK80) --output-file $@ --code 0100h $(SDK_RELS) CHKDSK.REL
-	$(call copy_to_bin,$@)
 
 # UNDEL is self-contained for the same reasons as CHKDSK (see above).
 UNDEL.COM: UNDEL.MAC $(SDK_RELS)
 	$(call assemble,UNDEL.MAC)
 	@$(LK80) --output-file $@ --code 0100h $(SDK_RELS) UNDEL.REL
-	$(call copy_to_bin,$@)
 
 # Build rules for each individual SDK shared routine .asm file (one per public routine).
 define shared_rel_rule
@@ -147,7 +150,6 @@ DATA.REL: \
 # sub-shell that runs the recipes of ../Makefile, so its tools-disk target
 # passes WORKING_DIR explicitly instead.
 
-BIN_TOOLS := ../../bin/tools
 TOOLS_DSK := $(BIN_TOOLS)/nextor.dsk
 
 WORKING_DIR ?= $(or $(PWD),$(CURDIR))

--- a/source/tools/Makefile
+++ b/source/tools/Makefile
@@ -47,20 +47,26 @@ asm-tools: $(BIN_COMS)
 
 # The bin/tools copies are targets of their own (not a side effect of the
 # link recipes), so they get re-created when bin/tools is missing or empty
-# even if the .COM files in this directory are up to date.
-$(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM
+# even if the .COM files in this directory are up to date. The directory
+# itself is an order-only prerequisite: it gets created on demand, but its
+# timestamp changes never trigger a re-copy.
+$(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM | $(BIN_TOOLS)
 	cp $< $@
 
-.PHONY: prerequisites
+$(BIN_TOOLS):
+	@mkdir -p $@
 
 TOOLS := N80 LK80
 
-prerequisites:
-	@mkdir -p $(BIN_TOOLS)
-	$(foreach exec,$(TOOLS),\
-		$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
-
--include prerequisites
+# Check that the required tools are available. This is done at parse time
+# (not in a recipe) so that it runs before anything else regardless of the
+# make version: the former "-include prerequisites" trick relied on make
+# running a phony target's recipe at startup, which GNU make 4.4+ no longer
+# does. Skipped when just cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+$(foreach exec,$(TOOLS),\
+	$(if $(shell which $(exec)),,$(error "ERROR: can't execute $(exec), is it installed/in PATH?")))
+endif
 
 .SECONDEXPANSION:
 $(GENERIC_COMS): \

--- a/source/tools/Makefile
+++ b/source/tools/Makefile
@@ -56,6 +56,8 @@ $(BIN_COMS): $(BIN_TOOLS)/%.COM: %.COM | $(BIN_TOOLS)
 $(BIN_TOOLS):
 	@mkdir -p $@
 
+.PHONY: asm-tools
+
 TOOLS := N80 LK80
 
 # Check that the required tools are available. This is done at parse time


### PR DESCRIPTION
Fixes a few related problems in how the Makefiles in `source/` publish
their outputs to `bin/`. Each one is a separate commit.

## The bin/tools copies are now proper make targets

`make tools-all` (and `make all`) failed with "missing in ../../bin/tools"
when bin/tools was missing or empty but NEXTOR.SYS, COMMAND3.COM and the
.COM tools were up to date in their source directories: the copy to
bin/tools was a side effect of the build recipes, which don't run in that
case. The copies are now targets of their own that depend on the built
file, so they are re-created whenever they are missing.

Also fixes a `.phony`/`.PHONY` typo in `tools/Makefile`.

## The bin/ directories are created via order-only prerequisites

All six Makefiles created their bin/ output directory (and checked that the
required tools are in PATH) from a phony `prerequisites` target pulled in
with `-include prerequisites`, relying on make running its recipe while
"remaking" the included makefile at startup. GNU make 4.4 stopped doing that
for phony targets, so with make 4.4+ the recipe never runs: on a fresh clone
the first `cp` into bin/ fails with "No such file or directory", and the
tool checks are silently skipped. CI is unaffected for now (ubuntu-24.04
ships make 4.3), but a clean build already fails on distributions that ship
make 4.4+ (Arch, Fedora, Debian trixie, Homebrew's gmake...).

The trick is replaced with the standard approach: the output directories are
real targets (`mkdir -p`) listed as an order-only prerequisite (`| dir`) of
every rule that writes into them, so the directory exists before the recipe
runs but its timestamp changes never trigger rebuilds; and the tool
availability check runs at parse time, so it happens before anything else
on any make version (it's skipped when the only goal is `clean`, which
needs none of the tools).

## The published kernel base file is a proper make target too

Same problem as the tools copies, in the kernel: the copy of
`nextor_base.dat` to bin/kernel-base was a side effect of the
`nextor_base.dat` recipe, so with the kernel up to date and bin/ wiped,
`make base` left bin/kernel-base empty. The variant-named published file
is now a target of its own that depends on `nextor_base.dat`, and `base`
depends on it.

With that, the drivers Makefile no longer needs its own copy of that file
(it existed only to survive a wiped bin/): its `base` target now just runs
the kernel sub-make, which publishes the file itself.

## Aggregate targets declared as phony

`all` and `base` in the kernel Makefile and `asm-tools` in the tools
Makefile weren't declared as `.PHONY`, unlike their counterparts in the
other Makefiles.

## Verification

Tested with GNU make 4.3 and with 4.4.1 built from source, in both cases:
full build from scratch (`make -C source`), no-op rebuild, `tools-all`
after wiping bin/tools, rebuild after wiping all of bin/ with up-to-date
sources, `make -C source/drivers` on its own (including the incremental
chain when the kernel base changes), `make -C source/kernel everything`
(all twelve variant files present), `make clean` without the tools
installed, and a `-j8` build from scratch.