### PR TITLE
Fix: crash with 4+SHIFT pressed at boot

### DIFF
--- a/source/kernel/bank1/mapinit.mac
+++ b/source/kernel/bank1/mapinit.mac
@@ -16,6 +16,7 @@ P2_REG		equ	0FEh
 P3_REG		equ	0FFh
 
 MSXVER	equ	002Dh
+CHGCPU	equ	0180h
 ;
 ;
 ;-----------------------------------------------------------------------------
@@ -151,7 +152,24 @@ if (BUILTIN AND STURBO)
 		ld	a,(BOOTKEYS##)
 		and	00010000b   ;4 key pressed?
 		ld	a,b
-		jr	nz,NOTR2
+		jr	z,NO4KEY
+
+		;"4" key pressed: the last four segments, which hold the R800 DRAM
+		;mode copies of the BIOS, the sub-ROM and the Kanji driver ROM, are
+		;about to be reused as the kernel code and data segments. So switch
+		;the CPU to R800 ROM mode right now: INIT does it too (CHECK_1KEY),
+		;but only after DOSINIT has already overwritten these segments, and
+		;if the CPU is still in DRAM mode at that point (e.g. because the
+		;internal MSX-DOS 2 kernel left it so after being disabled with
+		;SHIFT) the computer crashes.
+
+		push	af
+		ld	a,81h
+		call	CHGCPU
+		di ;CHGCPU enables interrupts but MAP_INIT must run with them disabled.
+		pop	af
+		jr	NOTR2
+NO4KEY:
 		sub	4
 NOTR2:
 endif


### PR DESCRIPTION
## Summary

Booting a MSX turbo R with both the `4` boot key (R800 ROM mode, free the 64K reserved for R800 DRAM mode) and `SHIFT` (disable MSX-DOS kernels) pressed hangs the computer right after the drivers are initialized. The cause is that Nextor reuses the memory that holds the R800 DRAM mode copies of the system ROMs while the CPU is still running in DRAM mode. This pull request switches the CPU to R800 ROM mode before that memory is reused.

## Root cause

At boot a Turbo-R runs in R800 DRAM mode: the S1990 serves the BIOS, BASIC, sub-ROM and Kanji driver ROM from copies kept in the last four segments of the internal mapper (segments 28 to 31 on a 512K machine). Those are the four segments that MSX-DOS 2 (and Nextor) normally mark as reserved on a Turbo-R, and the ones the `4` boot key frees.

When `4` is pressed, `MAP_INIT` (bank 1, `mapinit.mac`) skips the `sub 4` and so takes the last segment as the kernel data segment and the one before it as the kernel code segment: the DRAM mode copies of the Kanji driver ROM and of the sub-ROM. `DOSINIT` then zeroes the data segment and downloads the kernel code into the code segment. While the CPU is in DRAM mode those segments are the live ROM copies and the S1990 keeps them write protected (openMSX models this in `PanasonicMemory::isWritable`), so both writes are silently dropped: the kernel ends up executing the sub-ROM contents as its code segment and reading the Kanji driver ROM as its data segment, which is fatal within a few hundred instructions. This is only safe if the CPU is no longer in DRAM mode, but the switch to R800 ROM mode requested by the `4` key is done in `CHECK_1KEY` (bank 0, `init.mac`), which runs after `DOSINIT`.

Whether the CPU is in DRAM mode at that point depends on what ran before `DOSINIT`:

* Nextor switches to Z80 mode for the driver initialization and leaves the CPU there. With `4` alone the CPU is therefore in Z80 mode when `DOSINIT` runs, the ROM copies are not in use, and the boot succeeds.
* With `SHIFT` pressed the internal MSX-DOS 2 kernel (slot 3-2) finds the disk system disabled and, as the stock MSX-DOS 2 kernel does on a Turbo-R, switches the CPU back to R800 DRAM mode before returning. `DOSINIT` then runs with its code and data segments write protected and reading as the sub-ROM and Kanji driver ROM copies, and the kernel initialization goes off the rails as soon as it relies on them. On a FS-A1ST, for instance, execution wanders through the mirrored Kanji driver code, which calls one of its own routines by fixed address in page 1, lands in the empty area of Nextor bank 1, slides through NOPs into the bank switching code with a garbage bank number and ends in an interrupt storm (the `H.KEYI` hook reads as `FFh`). On a FS-A1GT the kernel simply ends up frozen in the BIOS with the hooks intact. In both cases the screen still shows "Driver initialization OK".

So `4` alone works only because of the order in which things happen to run, not by design. Anything that leaves the CPU in DRAM mode when `DOSINIT` runs, such as `SHIFT`, an internal disk ROM that behaves differently or no internal MSX-DOS kernel at all, triggers the crash.

## The fix

In `MAP_INIT`, when running on a turbo R with the `4` key pressed, call `CHGCPU` with `81h` (R800 ROM mode, LED update) right before the decision to reuse the last four segments. `CHGCPU` preserves all registers but ends with `EI`, and `MAP_INIT` must run with interrupts disabled, so a `DI` follows the call. `CHECK_1KEY` still performs its own switch later, which is now a no-op for this case.

`MAP_INIT` is entered with the BIOS in page 0 (that is part of the `DOSINIT` entry contract), so the BIOS routine can be called directly. Bank 1 has plenty of free space, which is why the fix lives there rather than in bank 0's `init.mac`, whose code is pinned by `ALIGN` directives.

Side effect worth knowing: with `4` pressed, the rest of `DOSINIT` (kernel init, boot sector read) now runs in R800 ROM mode instead of Z80 mode. Driver calls that need the Z80 keep being handled by the existing Z80 access mode mechanism.

## Testing

Reproduced and verified with openMSX 21.0 on two turbo R configurations, a Panasonic FS-A1ST with 512K RAM and a Panasonic FS-A1GT, both with a Sunrise IDE Nextor 3.0.0 beta 1 ROM in slot 1 and IDE master and slave hard disk images attached, from a factory-fresh machine state each run (the openMSX persistent CMOS is corrupted by the crash and makes later runs behave differently if it is not reset).

Reverse debugging (`reverse goto` and `step_back`) was used to bisect the exact instruction sequence, and the diagnosis was validated before writing the patch by injecting a `CHGCPU(81h)` call at the `DOSINIT` entry from the debugger, which turned the crash into a normal boot.

A control ROM built from unmodified `master` with the Sunrise IDE driver is byte-identical to the shipped beta 1 ROM. The patched ROM differs only in bank 1. Boot results with keys held from power-on, identical on both machines unless noted:

| Keys held | Unmodified master | This PR |
|-----------|-------------------|---------|
| 4 + SHIFT | hangs after "Driver initialization OK" (interrupt storm on the FS-A1ST, frozen in the BIOS with the hooks intact on the FS-A1GT) | boots to the prompt, CPU in R800 ROM mode |
| 4 | boots, R800 ROM mode | boots, R800 ROM mode |
| SHIFT | boots, R800 DRAM mode | boots, R800 DRAM mode |
| none | boots, R800 DRAM mode | boots, R800 DRAM mode |
| 2 + SHIFT | boots in MSX-DOS 1 mode | boots in MSX-DOS 1 mode |

The exact way the crash manifests differs between the two machines because the garbage executed after the ROM copies are overwritten differs, but the trigger is the same: on both, `DOSINIT` is entered in R800 DRAM mode with 4 + SHIFT and in Z80 mode with 4 alone. Not tested on real hardware.
