### PR TITLE
Add OCM to the list of known drivers

### DIFF
--- a/docs/Nextor_3.0_Known_Drivers.md
+++ b/docs/Nextor_3.0_Known_Drivers.md
@@ -12,7 +12,7 @@ These are the known device drivers available for Nextor 3:
 | MegaFlashROM SCC+ SD | [MegaFlashROM SCC+ SD](https://www.msxcartridgeshop.com/) cartridges | [MegaFlashROM-SD-Nextor-driver](https://github.com/Konamiman/MegaFlashROM-SCC-SD-Nextor-driver) |
 | FlashJacks | FlashJacks IDE interface | [Flashjacks-Nextor-driver](https://github.com/Konamiman/Flashjacks-Nextor-driver) |
 | MSX Turbo-R FDD | The floppy disk controller built into the MSX Turbo-R computers (Panasonic FS-A1GT and FS-A1ST); can be built as a ROM kernel or as a RAM-loadable driver | [TurboR-FDD-Nextor-driver](https://github.com/Konamiman/Turbo-R-FDD-Nextor-driver) |
-| OCM | 1chipMSX and other similar FPGA-based machines | [KdL Index](https://gnogni.altervista.org/) |
+| OCM | 1chipMSX and other similar FPGA-based machines | [KdL Index!](https://gnogni.altervista.org/) |
 
 Additionally, the Nextor repository itself contains [the standalone ROM driver](https://github.com/Konamiman/Nextor/blob/HEAD/source/drivers/standalone-rom-driver.asm) (a dummy driver that doesn't handle any real hardware, used to build the standalone Nextor ROMs) and [an example RAM-loadable driver](https://github.com/Konamiman/Nextor/blob/HEAD/source/drivers/ram-driver-example.asm); both are useful as reference code when developing a new driver.
 

--- a/docs/Nextor_3.0_Known_Drivers.md
+++ b/docs/Nextor_3.0_Known_Drivers.md
@@ -12,13 +12,12 @@ These are the known device drivers available for Nextor 3:
 | MegaFlashROM SCC+ SD | [MegaFlashROM SCC+ SD](https://www.msxcartridgeshop.com/) cartridges | [MegaFlashROM-SD-Nextor-driver](https://github.com/Konamiman/MegaFlashROM-SCC-SD-Nextor-driver) |
 | FlashJacks | FlashJacks IDE interface | [Flashjacks-Nextor-driver](https://github.com/Konamiman/Flashjacks-Nextor-driver) |
 | MSX Turbo-R FDD | The floppy disk controller built into the MSX Turbo-R computers (Panasonic FS-A1GT and FS-A1ST); can be built as a ROM kernel or as a RAM-loadable driver | [TurboR-FDD-Nextor-driver](https://github.com/Konamiman/Turbo-R-FDD-Nextor-driver) |
+| OCM | 1chipMSX and other similar FPGA-based machines | [KdL Index](https://gnogni.altervista.org/) |
 
 Additionally, the Nextor repository itself contains [the standalone ROM driver](https://github.com/Konamiman/Nextor/blob/HEAD/source/drivers/standalone-rom-driver.asm) (a dummy driver that doesn't handle any real hardware, used to build the standalone Nextor ROMs) and [an example RAM-loadable driver](https://github.com/Konamiman/Nextor/blob/HEAD/source/drivers/ram-driver-example.asm); both are useful as reference code when developing a new driver.
 
 Notes:
 
 * The Nextor 2 versions of these drivers (except the Turbo-R FDD driver, which is new in Nextor 3) remain available in [the v2.1 branch](https://github.com/Konamiman/Nextor/tree/v2.1/source/kernel/drivers) of the Nextor repository. Remember that Nextor 2 drivers don't work with Nextor 3 and vice versa; see [the Nextor 3.0 Driver Migration Guide](Nextor_3.0_Driver_Migration_Guide.md) for how to adapt a Nextor 2 driver to Nextor 3.
-
-* The OCM (One Chip MSX) driver that was part of Nextor 2 has been discontinued, since its source code is not available.
 
 If you have developed a driver for Nextor 3 and want it listed here (no matter how you distribute it: a git repository, a dedicated web site, plain downloadable binaries...), please open an issue or a pull request in [the Nextor repository](https://github.com/Konamiman/Nextor).


### PR DESCRIPTION
Adds KdL's [OCM packs page](https://gnogni.altervista.org/) to the list of known Nextor drivers.
