### PR TITLE
devinfo: Fix manufacturer.

### DIFF
--- a/source/tools/DEVINFO.MAC
+++ b/source/tools/DEVINFO.MAC
@@ -92,13 +92,13 @@ GET_INFO_1:
 
 	push af
 	ld a,(iy+2)
-	ld ix,BUF_INFO
+	ld ix,BUF_NUMBER
 	call BYTE2ASC##
 	ld (ix),0
 	ld	de,DEV_MSG
 	ld	c,_ZSTROUT##
 	call	5
-	ld de,BUF_INFO
+	ld de,BUF_NUMBER
 	ld	c,_ZSTROUT##
 	call	5
 	ld	de,CRLF
@@ -506,6 +506,7 @@ BUF: equ 2000h
 BUF_DEV_IS_ONLINE: equ BUF
 BUF_REG: equ BUF_DEV_IS_ONLINE+1
 BUF_REG2	equ	BUF_REG+8
-BUF_INFO	equ	BUF_REG2+8
+BUF_NUMBER	equ	BUF_REG2+8
+BUF_INFO	equ	BUF_NUMBER+4
 
 	end


### PR DESCRIPTION
Use a separate buffer to format the device number so printing the device heading no longer overwrites the manufacturer string.

Before:

```
D:¥>devinfo 1-3
Device number 2
  Device manufacturer: 2
  Medium name: enMSX
  Device serial number: 12345678
  Block device, 8192KB, removable

Device number 3
  Device manufacturer: 3
  Medium name: enMSX
  Device serial number: 12345678
  Block device, 100MB, removable
```

After:

```
D:¥>devinfo 1-3
Device number 2
  Device manufacturer: openMSX[AA]
  Medium name: enMSX
  Device serial number: 12345678
  Block device, 8192KB, removable

Device number 3
  Device manufacturer: openMSX[AA]
  Medium name: enMSX
  Device serial number: 12345678
  Block device, 100MB, removable
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the usage banner to report DEVINFO v1.3.
  - Improved device information output by displaying device numbers separately from driver-provided information while preserving returned text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->