### PR TITLE
partit: Fix off-by-one in MAPDRV_DOS1.

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -4519,16 +4519,16 @@ MAPDOS1_CHECK_LOOP:
 	jr	nz,MAPDOS1_CHK_NEXT
 
 	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##)	;Check starting sector
-	cp	(iy+3)
-	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+1)
 	cp	(iy+4)
 	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+2)
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+1)
 	cp	(iy+5)
 	jr	nz,MAPDOS1_CHK_NEXT
-	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+3)
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+2)
 	cp	(iy+6)
+	jr	nz,MAPDOS1_CHK_NEXT
+	ld	a,(ix+UD1_FIRST_ABSOLUTE_SECTOR##+3)
+	cp	(iy+7)
 	jr	nz,MAPDOS1_CHK_NEXT
 
 	pop	ix


### PR DESCRIPTION
In `MAPDOS1_CHECK_LOOP` it would compare the starting sector at `iy` offsets 3-6, however when it actually performs the mapping in `MAPDOS1_CHK_NEXT` it uses `iy` offsets 4-7.

The `_MAPDRV` documentation specifies that the latter is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected duplicate-drive mapping checks in DOS 1 so partition sectors are compared accurately.
  * Prevented the unused logical unit field from being included in duplicate-mapping comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->