### PR TITLE
partit: DEV_READ should receive media descriptor.

### DIFF
--- a/source/kernel/bank4/partit.mac
+++ b/source/kernel/bank4/partit.mac
@@ -121,6 +121,7 @@ F_GPART_INNER:
 	ld	(TMP_SEC##+1),a
 	ld	(TMP_SEC##+2),a
 	ld	(TMP_SEC##+3),a
+	ld	e,a			;Boot sector media descriptors are unknown
 	call	DEV_READ
 	ret	nz
 
@@ -316,8 +317,9 @@ UPDATE_SEC:
 
 ;This routine reads one sector into SECBUF
 ;Input: C = Driver slot
-;       B = Driver segment (FFh for ROM drivers), currently ignored
+;       B = Driver segment (FFh for ROM drivers)
 ;       D = Device number
+;       E = Media descriptor
 ;       (TMP_SEC##) = Sector number
 ;Output: A = Error code from DEV_RW
 ;        NZ if A<>0
@@ -352,7 +354,7 @@ DEV_READ_RAM:
 	ld	h,c		;H = slot
 	ld	l,b		;L = segment
 	ld	a,d		;A = device number
-	ld	c,e		;C = LUN
+	ld	c,e		;C = media descriptor
 	ld	b,1		;B = 1 sector
 	push	hl		;Save slot:segment for IY
 	ld	hl,($SECBUF##)	;HL = buffer


### PR DESCRIPTION
The LUN parameter was removed and register `e` now contains the media descriptor. However this was not documented, and also no longer provided by its callers. When retrieving the boot sectors the media descriptor is not yet known, so it should provide the value `0`, as specified in the `READ_WRITE` driver documentation.

Also removed an outdated remark about driver segment being ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk read handling by passing the correct media descriptor to the driver.
  * Boot-sector reads now explicitly handle unknown media descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->